### PR TITLE
Reset scheduler before talker graph allocation

### DIFF
--- a/src/talker-forward.h
+++ b/src/talker-forward.h
@@ -330,6 +330,7 @@ static bool talker_forward_core(const TalkerWeights * tw,
     }
     ggml_build_forward_expand(gf, logits);
 
+    ggml_backend_sched_reset(sched);
     if (!ggml_backend_sched_alloc_graph(sched, gf)) {
         fprintf(stderr, "[TalkerForward] FATAL: graph allocation failed\n");
         ggml_backend_sched_reset(sched);


### PR DESCRIPTION
## Summary

Reset the GGML scheduler immediately before allocating the talker graph.

This fixes the CPU speech regression seen after prompt-projection graphs without falling back to host-side prompt projection. CPU and CUDA both keep the backend prompt-projection path.

## Why

On aarch64 CPU, the prompt embeddings produced by the failing path and the fixed path were identical, but the first talker prefill graph diverged after a prior prompt-projection graph. Resetting the scheduler before `ggml_backend_sched_alloc_graph` makes the CPU first hidden/logits and first-frame codes match the good path.

## Validation

Local GB10/aarch64 validation, Qwen3-TTS 12Hz 1.7B CustomVoice BF16, speaker `aiden`, cached GGUF files:

- CPU reset-before local: STT passed greedy and sampled clips.
- CUDA 13 reset-before local: STT passed greedy and sampled clips.
- CUDA 12.8 wheel: STT passed greedy and sampled clips.
- CUDA 13.0 wheel: STT passed greedy and sampled clips.

Artifacts:

- Timings: https://raw.githubusercontent.com/andimarafioti/qwentts.cpp/cpu-reset-audio-artifacts/all-options/timings.md
- Manifest: https://raw.githubusercontent.com/andimarafioti/qwentts.cpp/cpu-reset-audio-artifacts/all-options/manifest.json
- WAVs: https://github.com/andimarafioti/qwentts.cpp/tree/cpu-reset-audio-artifacts/all-options/samples
