### PR TITLE
pipeline-codec: reset sched before encode alloc

### DIFF
--- a/src/pipeline-codec.cpp
+++ b/src/pipeline-codec.cpp
@@ -692,6 +692,10 @@ std::vector<int32_t> pipeline_codec_encode(PipelineCodec * pc,
         ggml_build_forward_expand(graph, sn_stage3_dump);
     }
 
+    // Reset before alloc: a prior decode/synthesis may have left the shared
+    // codec sched allocated, which trips GGML_ASSERT(!sched->is_alloc). Mirrors
+    // the decode path (top of this file) and speaker_encoder_extract.
+    ggml_backend_sched_reset(pc->sched);
     if (!ggml_backend_sched_alloc_graph(pc->sched, graph)) {
         qt_log(QT_LOG_ERROR, "[Pipeline] encode sched_alloc_graph failed");
         ggml_backend_sched_reset(pc->sched);


### PR DESCRIPTION
The codec encode path (`pipeline_codec_encode`) calls `ggml_backend_sched_alloc_graph` without first calling `ggml_backend_sched_reset`, unlike every sibling path — the decode path at the top of the same file, `prompt-builder.h`, and `speaker_encoder_extract`.

Once a synthesis call leaves the shared codec sched in the allocated state, the next RVQ encode allocs on a still-allocated sched and trips:

```
ggml/src/ggml-backend.cpp:1867: GGML_ASSERT(!sched->is_alloc) failed
```

in `ggml_backend_sched_alloc_graph`, crashing the server.

### Repro (base model, `POST /v1/voices`)
1. Register a cloned voice from a WAV — succeeds.
2. Generate speech.
3. Register another voice.

Second register crashes without this fix. Log ends with a successful `[SpkExtract] Extracted ...` (the extract resets its own sched) immediately followed by the assert, because the crash is in the codec encode that runs right after.

### Fix
Reset the sched before alloc in the encode path, matching the other call sites. One line.