### PR TITLE
Add Dockerfile (cpu/cuda/vulkan), entrypoint, docs, and a GHCR build/release workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+build
+checkpoints
+models
+docs
+examples
+*.md

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        variant: [cpu, cuda]
+        variant: [cpu, cuda, vulkan]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,65 @@
+name: Docker
+
+on:
+  push:
+    branches: [master]
+    tags: ['v*']
+  pull_request:
+    paths:
+      - 'Dockerfile'
+      - 'docker/**'
+      - '.dockerignore'
+      - '.github/workflows/docker.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: [cpu, cuda]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute tags
+        id: tags
+        shell: bash
+        run: |
+          image="ghcr.io/${{ github.repository }}"
+          variant="${{ matrix.variant }}"
+          tags="${image}:${variant}-${{ github.sha }}"
+          if [ "${{ github.ref }}" = "refs/heads/master" ]; then
+            tags="${tags},${image}:${variant}"
+          fi
+          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            version="${GITHUB_REF_NAME#v}"
+            tags="${tags},${image}:${variant}-v${version}"
+          fi
+          echo "tags=${tags}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: ${{ matrix.variant }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.tags.outputs.tags }}
+          cache-from: type=gha,scope=${{ matrix.variant }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.variant }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,15 +24,15 @@ jobs:
       matrix:
         variant: [cpu, cuda, vulkan]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -55,7 +55,7 @@ jobs:
           echo "tags=${tags}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           target: ${{ matrix.variant }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,14 +46,17 @@ if(NOT MSVC AND NOT GGML_SYCL)
     add_compile_definitions(_FORTIFY_SOURCE=2)
 endif()
 
-# CUDA architectures: cover Turing to Blackwell for distributed binaries.
+# CUDA architectures: cover Pascal to Blackwell for distributed binaries.
+# Pascal (61-real) is SASS-only, no virtual/PTX entry: it's the oldest
+# supported card and doesn't need to seed forward JIT compat for anything
+# older, unlike the 75-virtual baseline which does that for 7.5+.
 # Users can override with -DCMAKE_CUDA_ARCHITECTURES=native for local builds.
 if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
     find_package(CUDAToolkit QUIET)
     if(CUDAToolkit_FOUND AND CUDAToolkit_VERSION VERSION_GREATER_EQUAL "12.8")
-        set(CMAKE_CUDA_ARCHITECTURES "75-virtual;80-virtual;86-real;89-real;120a-real;121a-real")
+        set(CMAKE_CUDA_ARCHITECTURES "61-real;75-virtual;80-virtual;86-real;89-real;120a-real;121a-real")
     else()
-        set(CMAKE_CUDA_ARCHITECTURES "75-virtual;80-virtual;86-real;89-real")
+        set(CMAKE_CUDA_ARCHITECTURES "61-real;75-virtual;80-virtual;86-real;89-real")
     endif()
 endif()
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN cmake -B build -DGGML_BLAS=ON -DCMAKE_BUILD_TYPE=Release && \
 
 FROM ubuntu:22.04 AS cpu
 RUN apt-get update -qq && apt-get install -y -qq --no-install-recommends \
-        libgomp1 libopenblas0 curl ca-certificates \
+        libgomp1 libopenblas0 curl ca-certificates jq \
     > /dev/null && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY --from=build-cpu /build/build/tts-server /build/build/qwen-tts /build/build/qwen-codec /build/build/*.so* ./
@@ -70,7 +70,7 @@ RUN cmake -B build -DGGML_CUDA=ON \
 
 FROM ${CUDA_RUNTIME_IMAGE} AS cuda
 RUN apt-get update -qq && apt-get install -y -qq --no-install-recommends \
-        libgomp1 curl ca-certificates \
+        libgomp1 curl ca-certificates jq \
     > /dev/null && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY --from=build-cuda /build/build/tts-server /build/build/qwen-tts /build/build/qwen-codec /build/build/*.so* ./
@@ -98,7 +98,7 @@ RUN cmake -B build -DGGML_VULKAN=ON -DCMAKE_BUILD_TYPE=Release && \
 
 FROM ubuntu:22.04 AS vulkan
 RUN apt-get update -qq && apt-get install -y -qq --no-install-recommends \
-        libgomp1 libvulkan1 mesa-vulkan-drivers curl ca-certificates \
+        libgomp1 libvulkan1 mesa-vulkan-drivers curl ca-certificates jq \
     > /dev/null && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY --from=build-vulkan /build/build/tts-server /build/build/qwen-tts /build/build/qwen-codec /build/build/*.so* ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,11 @@
 #   docker build --target cuda   -t qwentts.cpp:cuda   .
 #   docker build --target vulkan -t qwentts.cpp:vulkan .
 #
-# Pascal (sm_61) and other GPUs older than this project's default
-# distributed arch list (Turing+) need an explicit override, since
+# This project's default distributed arch list covers Pascal (sm_61) to
+# Blackwell. GPUs older than that need an explicit override, since
 # `docker build` has no GPU device to auto-detect against:
 #   docker build --target cuda -t qwentts.cpp:cuda \
-#       --build-arg CMAKE_CUDA_ARCHITECTURES=61 .
+#       --build-arg CMAKE_CUDA_ARCHITECTURES=50 .   # Maxwell
 # See docs/DOCKER.md for details.
 
 ARG CUDA_BUILD_IMAGE=nvidia/cuda:12.4.1-devel-ubuntu22.04
@@ -53,8 +53,8 @@ COPY . .
 # `docker build` never has GPU device access, unlike `docker run --gpus`, so:
 #  - CMAKE_CUDA_ARCHITECTURES must be set explicitly when targeting a GPU
 #    generation outside this project's own default arch list (see
-#    docs/DOCKER.md for the Pascal/sm_61 example); when unset here, CMake's
-#    own project default (Turing and newer) is used unchanged.
+#    docs/DOCKER.md); when unset here, CMake's own project default
+#    (Pascal and newer) is used unchanged.
 #  - ggml's CUDA VMM pool allocator needs driver-API symbols (cuMemCreate,
 #    cuMemMap, ...) at link time. The real libcuda.so isn't present without
 #    a GPU, but the devel image ships a link-time-only stub at

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,9 @@
 # `submodules: recursive` in CI) -- this Dockerfile does not fetch it.
 #
 # Usage:
-#   docker build --target cpu  -t qwentts.cpp:cpu  .
-#   docker build --target cuda -t qwentts.cpp:cuda .
+#   docker build --target cpu    -t qwentts.cpp:cpu    .
+#   docker build --target cuda   -t qwentts.cpp:cuda   .
+#   docker build --target vulkan -t qwentts.cpp:vulkan .
 #
 # Pascal (sm_61) and other GPUs older than this project's default
 # distributed arch list (Turing+) need an explicit override, since
@@ -73,6 +74,34 @@ RUN apt-get update -qq && apt-get install -y -qq --no-install-recommends \
     > /dev/null && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY --from=build-cuda /build/build/tts-server /build/build/qwen-tts /build/build/qwen-codec /build/build/*.so* ./
+COPY docker/entrypoint.sh ./entrypoint.sh
+RUN chmod +x ./entrypoint.sh
+ENV LD_LIBRARY_PATH=/app
+ENTRYPOINT ["./entrypoint.sh"]
+
+# ------------------------------------------------------------- Vulkan build
+# AMD/Intel GPUs (and NVIDIA via its Vulkan ICD). glslc (shader compiler) is
+# only packaged by the LunarG SDK repo on Ubuntu 22.04, not apt's universe.
+FROM ubuntu:22.04 AS build-vulkan
+RUN apt-get update -qq && apt-get install -y -qq --no-install-recommends \
+        git ca-certificates cmake g++ make wget gnupg \
+    > /dev/null && rm -rf /var/lib/apt/lists/*
+RUN wget -qO- https://packages.lunarg.com/lunarg-signing-key-pub.asc | gpg --dearmor -o /usr/share/keyrings/lunarg.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/lunarg.gpg] https://packages.lunarg.com/vulkan/1.3.296 jammy main" \
+        > /etc/apt/sources.list.d/lunarg-vulkan.list && \
+    apt-get update -qq && apt-get install -y -qq --no-install-recommends vulkan-sdk \
+    > /dev/null && rm -rf /var/lib/apt/lists/*
+WORKDIR /build
+COPY . .
+RUN cmake -B build -DGGML_VULKAN=ON -DCMAKE_BUILD_TYPE=Release && \
+    cmake --build build --config Release -j"$(nproc)"
+
+FROM ubuntu:22.04 AS vulkan
+RUN apt-get update -qq && apt-get install -y -qq --no-install-recommends \
+        libgomp1 libvulkan1 mesa-vulkan-drivers curl ca-certificates \
+    > /dev/null && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY --from=build-vulkan /build/build/tts-server /build/build/qwen-tts /build/build/qwen-codec /build/build/*.so* ./
 COPY docker/entrypoint.sh ./entrypoint.sh
 RUN chmod +x ./entrypoint.sh
 ENV LD_LIBRARY_PATH=/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,79 @@
+# syntax=docker/dockerfile:1
+#
+# Build context must have the `ggml` submodule checked out already
+# (`git clone --recurse-submodules`, or `actions/checkout` with
+# `submodules: recursive` in CI) -- this Dockerfile does not fetch it.
+#
+# Usage:
+#   docker build --target cpu  -t qwentts.cpp:cpu  .
+#   docker build --target cuda -t qwentts.cpp:cuda .
+#
+# Pascal (sm_61) and other GPUs older than this project's default
+# distributed arch list (Turing+) need an explicit override, since
+# `docker build` has no GPU device to auto-detect against:
+#   docker build --target cuda -t qwentts.cpp:cuda \
+#       --build-arg CMAKE_CUDA_ARCHITECTURES=61 .
+# See docs/DOCKER.md for details.
+
+ARG CUDA_BUILD_IMAGE=nvidia/cuda:12.4.1-devel-ubuntu22.04
+ARG CUDA_RUNTIME_IMAGE=nvidia/cuda:12.4.1-runtime-ubuntu22.04
+
+# ---------------------------------------------------------------- CPU build
+FROM ubuntu:22.04 AS build-cpu
+RUN apt-get update -qq && apt-get install -y -qq --no-install-recommends \
+        git ca-certificates cmake g++ make pkg-config libopenblas-dev \
+    > /dev/null && rm -rf /var/lib/apt/lists/*
+WORKDIR /build
+COPY . .
+RUN cmake -B build -DGGML_BLAS=ON -DCMAKE_BUILD_TYPE=Release && \
+    cmake --build build --config Release -j"$(nproc)"
+
+FROM ubuntu:22.04 AS cpu
+RUN apt-get update -qq && apt-get install -y -qq --no-install-recommends \
+        libgomp1 libopenblas0 curl ca-certificates \
+    > /dev/null && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY --from=build-cpu /build/build/tts-server /build/build/qwen-tts /build/build/qwen-codec /build/build/*.so* ./
+COPY docker/entrypoint.sh ./entrypoint.sh
+RUN chmod +x ./entrypoint.sh
+# Binaries are copied out of the build tree their RPATH points at, so the
+# ggml shared libraries (copied alongside, above) need an explicit search path.
+ENV LD_LIBRARY_PATH=/app
+ENTRYPOINT ["./entrypoint.sh"]
+
+# --------------------------------------------------------------- CUDA build
+FROM ${CUDA_BUILD_IMAGE} AS build-cuda
+ARG CMAKE_CUDA_ARCHITECTURES
+RUN apt-get update -qq && apt-get install -y -qq --no-install-recommends \
+        git ca-certificates cmake g++ make \
+    > /dev/null && rm -rf /var/lib/apt/lists/*
+WORKDIR /build
+COPY . .
+# `docker build` never has GPU device access, unlike `docker run --gpus`, so:
+#  - CMAKE_CUDA_ARCHITECTURES must be set explicitly when targeting a GPU
+#    generation outside this project's own default arch list (see
+#    docs/DOCKER.md for the Pascal/sm_61 example); when unset here, CMake's
+#    own project default (Turing and newer) is used unchanged.
+#  - ggml's CUDA VMM pool allocator needs driver-API symbols (cuMemCreate,
+#    cuMemMap, ...) at link time. The real libcuda.so isn't present without
+#    a GPU, but the devel image ships a link-time-only stub at
+#    lib64/stubs/libcuda.so for exactly this case; it isn't on the default
+#    linker search path so both -L and -lcuda are needed explicitly.
+RUN cmake -B build -DGGML_CUDA=ON \
+        -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc \
+        ${CMAKE_CUDA_ARCHITECTURES:+-DCMAKE_CUDA_ARCHITECTURES=${CMAKE_CUDA_ARCHITECTURES}} \
+        -DCMAKE_EXE_LINKER_FLAGS="-L/usr/local/cuda/lib64/stubs -lcuda" \
+        -DCMAKE_SHARED_LINKER_FLAGS="-L/usr/local/cuda/lib64/stubs -lcuda" \
+        -DCMAKE_BUILD_TYPE=Release && \
+    cmake --build build --config Release -j"$(nproc)"
+
+FROM ${CUDA_RUNTIME_IMAGE} AS cuda
+RUN apt-get update -qq && apt-get install -y -qq --no-install-recommends \
+        libgomp1 curl ca-certificates \
+    > /dev/null && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY --from=build-cuda /build/build/tts-server /build/build/qwen-tts /build/build/qwen-codec /build/build/*.so* ./
+COPY docker/entrypoint.sh ./entrypoint.sh
+RUN chmod +x ./entrypoint.sh
+ENV LD_LIBRARY_PATH=/app
+ENTRYPOINT ["./entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ cd qwentts.cpp
 NVCC_CCBIN=g++-13 ./buildcuda.sh # rolling release distros (Arch w/ GCC 16, etc.)
 ```
 
+Docker images (CPU and CUDA, built and published on every release) are
+also available: see [docs/DOCKER.md](docs/DOCKER.md).
+
 ## Model conversion
 
 Pre-converted GGUFs are available on Hugging Face :

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # tts-server entrypoint: starts the server, then registers every reference
-# voice found in /voices (each *.wav registers under its filename stem)
-# once the server is ready to accept requests.
+# voice found in /voices (each *.wav registers under its filename stem,
+# optionally paired with a same-stem .txt for ref_text ICL cloning) once
+# the server is ready to accept requests.
 set -e
 
 MODEL=${MODEL_PATH:-/models/qwen-talker-1.7b-base-Q8_0.gguf}
@@ -16,6 +17,7 @@ extra_args=()
 [ -n "$CODEC_CHUNK_DUR" ] && extra_args+=(--codec-chunk-dur "$CODEC_CHUNK_DUR")
 [ -n "$CODEC_LEFT_DUR" ] && extra_args+=(--codec-left-dur "$CODEC_LEFT_DUR")
 [ -n "$MAX_BATCH" ] && extra_args+=(--max-batch "$MAX_BATCH")
+[ -n "$MAX_PREFILL_TOKENS" ] && extra_args+=(--max-prefill-tokens "$MAX_PREFILL_TOKENS")
 [ "$NO_FA" = "1" ] && extra_args+=(--no-fa)
 [ "$CLAMP_FP16" = "1" ] && extra_args+=(--clamp-fp16)
 
@@ -36,14 +38,32 @@ done
 for wav in /voices/*.wav; do
     [ -f "$wav" ] || continue
     name=$(basename "$wav" .wav)
-    b64=$(base64 -w0 "$wav")
-    printf '{"name":"%s","wav_b64":"%s"}' "$name" "$b64" > /tmp/voice_payload.json
-    echo "Registering voice '$name' from $wav"
+    # base64 payload can be multiple MB -- too large for an argv string
+    # (ARG_MAX), so it's written to a temp file and read in via jq's
+    # --rawfile rather than passed as a --arg.
+    b64_file=$(mktemp)
+    base64 -w0 "$wav" > "$b64_file"
+    txt="${wav%.wav}.txt"
+    # A same-stem .txt supplies the reference transcript, enabling ICL
+    # clone mode (higher fidelity) instead of the x_vector_only fallback
+    # used when no ref_text is sent. jq handles JSON-escaping arbitrary
+    # transcript text safely (quotes, backslashes, ...).
+    if [ -f "$txt" ]; then
+        echo "Registering voice '$name' from $wav (with ref_text from $txt)"
+        jq -n --arg name "$name" --rawfile wav_b64 "$b64_file" --rawfile ref_text "$txt" \
+            '{name: $name, wav_b64: $wav_b64, ref_text: ($ref_text | sub("\n+$"; ""))}' \
+            > /tmp/voice_payload.json
+    else
+        echo "Registering voice '$name' from $wav"
+        jq -n --arg name "$name" --rawfile wav_b64 "$b64_file" \
+            '{name: $name, wav_b64: $wav_b64}' \
+            > /tmp/voice_payload.json
+    fi
     curl -sf -X POST "http://localhost:${PORT}/v1/audio/voices" \
         -H "Content-Type: application/json" \
         -d @/tmp/voice_payload.json \
         && echo " -> ok" || echo " -> FAILED"
-    rm -f /tmp/voice_payload.json
+    rm -f /tmp/voice_payload.json "$b64_file"
 done
 
 wait "$SERVER_PID"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -66,4 +66,33 @@ for wav in /voices/*.wav; do
     rm -f /tmp/voice_payload.json "$b64_file"
 done
 
+# Optional fatal worst-case warmup: exercises one real end-to-end synthesis
+# capped at WARMUP_MAX_NEW_TOKENS frames, so the decode and codec-decode
+# compute buffers (the part that scales with output AUDIO length) get
+# reserved up front -- complementing --max-prefill-tokens above, which
+# only reserves for input TEXT length. Off by default: only runs when
+# WARMUP_VOICE names an already-registered voice. Failure is fatal (kills
+# the server and exits non-zero) by design: a deployment that can't
+# afford its own configured worst case should refuse to come up healthy,
+# not fail unpredictably on a live request later. The exact wording of
+# WARMUP_TEXT doesn't matter -- only that it's long enough the model
+# doesn't hit EOS on its own before WARMUP_MAX_NEW_TOKENS does, so the
+# warmup actually exercises the same truncation path a real over-length
+# response would hit in production.
+if [ -n "$WARMUP_VOICE" ]; then
+    WARMUP_MAX_NEW_TOKENS=${WARMUP_MAX_NEW_TOKENS:-750}
+    WARMUP_TEXT=${WARMUP_TEXT:-"This is a warmup sentence used to reserve worst case memory usage before accepting real requests. This is a warmup sentence used to reserve worst case memory usage before accepting real requests. This is a warmup sentence used to reserve worst case memory usage before accepting real requests."}
+    echo "Warming up with a ${WARMUP_MAX_NEW_TOKENS}-frame-capped synthesis to reserve worst-case VRAM..."
+    if ! curl -sf -X POST "http://localhost:${PORT}/v1/audio/speech" \
+        -H "Content-Type: application/json" \
+        -d "$(jq -n --arg voice "$WARMUP_VOICE" --arg input "$WARMUP_TEXT" --argjson max_new_tokens "$WARMUP_MAX_NEW_TOKENS" \
+            '{voice: $voice, input: $input, response_format: "pcm", max_new_tokens: $max_new_tokens}')" \
+        -o /dev/null; then
+        echo " -> FATAL: worst-case warmup synthesis failed (likely out of VRAM) -- refusing to come up healthy"
+        kill "$SERVER_PID" 2>/dev/null
+        exit 1
+    fi
+    echo " -> ok"
+fi
+
 wait "$SERVER_PID"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# tts-server entrypoint: starts the server, then registers every reference
+# voice found in /voices (each *.wav registers under its filename stem)
+# once the server is ready to accept requests.
+set -e
+
+MODEL=${MODEL_PATH:-/models/qwen-talker-1.7b-base-Q8_0.gguf}
+CODEC=${CODEC_PATH:-/models/qwen-tokenizer-12hz-Q8_0.gguf}
+LANG=${TTS_LANG:-auto}
+HOST=${HOST:-0.0.0.0}
+PORT=${PORT:-8080}
+ALIAS=${MODEL_ALIAS:-}
+
+extra_args=()
+[ -n "$ALIAS" ] && extra_args+=(--alias "$ALIAS")
+[ -n "$CODEC_CHUNK_DUR" ] && extra_args+=(--codec-chunk-dur "$CODEC_CHUNK_DUR")
+[ -n "$CODEC_LEFT_DUR" ] && extra_args+=(--codec-left-dur "$CODEC_LEFT_DUR")
+[ -n "$MAX_BATCH" ] && extra_args+=(--max-batch "$MAX_BATCH")
+[ "$NO_FA" = "1" ] && extra_args+=(--no-fa)
+[ "$CLAMP_FP16" = "1" ] && extra_args+=(--clamp-fp16)
+
+/app/tts-server \
+    --model "$MODEL" \
+    --codec "$CODEC" \
+    --lang "$LANG" \
+    --host "$HOST" \
+    --port "$PORT" \
+    "${extra_args[@]}" &
+SERVER_PID=$!
+
+until curl -sf "http://localhost:${PORT}/health" > /dev/null 2>&1; do
+    kill -0 "$SERVER_PID" 2>/dev/null || { echo "tts-server exited before becoming healthy" >&2; wait "$SERVER_PID"; }
+    sleep 1
+done
+
+for wav in /voices/*.wav; do
+    [ -f "$wav" ] || continue
+    name=$(basename "$wav" .wav)
+    b64=$(base64 -w0 "$wav")
+    printf '{"name":"%s","wav_b64":"%s"}' "$name" "$b64" > /tmp/voice_payload.json
+    echo "Registering voice '$name' from $wav"
+    curl -sf -X POST "http://localhost:${PORT}/v1/audio/voices" \
+        -H "Content-Type: application/json" \
+        -d @/tmp/voice_payload.json \
+        && echo " -> ok" || echo " -> FAILED"
+    rm -f /tmp/voice_payload.json
+done
+
+wait "$SERVER_PID"

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -56,6 +56,9 @@ image does not provide.
 | `MAX_PREFILL_TOKENS` | unset (server default: `0`, disabled)      |
 | `NO_FA`            | unset; set to `1` to disable flash attention  |
 | `CLAMP_FP16`       | unset; set to `1` to clamp hidden states      |
+| `WARMUP_VOICE`     | unset; set to a registered voice name to enable the startup warmup below |
+| `WARMUP_MAX_NEW_TOKENS` | `750` (only used when `WARMUP_VOICE` is set) |
+| `WARMUP_TEXT`      | a generic filler sentence (only used when `WARMUP_VOICE` is set) |
 
 Every `*.wav` placed in `/voices` is registered as a cloned voice
 under its filename stem (e.g. `/voices/freeman.wav` -> voice
@@ -64,6 +67,21 @@ under its filename stem (e.g. `/voices/freeman.wav` -> voice
 transcript of the reference clip -- which enables higher-fidelity ICL
 clone mode instead of the x_vector_only fallback used when no
 transcript is given.
+
+### Worst-case VRAM warmup
+
+`ggml_backend_sched` grows its compute buffer to fit the largest graph
+it has ever built and never shrinks it back, so VRAM use can ratchet
+up the first time a long prompt or a long reply arrives on live
+traffic. Setting `WARMUP_VOICE` runs one real synthesis at container
+startup, capped at `WARMUP_MAX_NEW_TOKENS` frames, to force that
+worst-case buffer growth to happen up front instead of on a live
+request. Combine with `--max-prefill-tokens` (`MAX_PREFILL_TOKENS`
+above) for the input side of the same problem. If the warmup
+synthesis fails (most likely out of VRAM), the container exits
+non-zero rather than come up healthy and fail unpredictably later --
+by design, since a deployment that can't afford its own configured
+worst case should know that at startup.
 
 ## Building locally
 

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -53,12 +53,17 @@ image does not provide.
 | `CODEC_CHUNK_DUR`  | unset (server default: `24.0`)               |
 | `CODEC_LEFT_DUR`   | unset (server default: `2.0`)                 |
 | `MAX_BATCH`        | unset (server default: `1`)                  |
+| `MAX_PREFILL_TOKENS` | unset (server default: `0`, disabled)      |
 | `NO_FA`            | unset; set to `1` to disable flash attention  |
 | `CLAMP_FP16`       | unset; set to `1` to clamp hidden states      |
 
 Every `*.wav` placed in `/voices` is registered as a cloned voice
 under its filename stem (e.g. `/voices/freeman.wav` -> voice
-`freeman`) once `/health` responds.
+`freeman`) once `/health` responds. A same-stem `.txt` file (e.g.
+`/voices/freeman.txt`) supplies that voice's `ref_text` -- the
+transcript of the reference clip -- which enables higher-fidelity ICL
+clone mode instead of the x_vector_only fallback used when no
+transcript is given.
 
 ## Building locally
 

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -1,0 +1,87 @@
+# Docker
+
+Pre-built images: `ghcr.io/serveurpersocom/qwentts.cpp:cpu` and
+`ghcr.io/serveurpersocom/qwentts.cpp:cuda` (also tagged per release,
+e.g. `:cuda-v1.2.3`). Both run `tts-server`; `qwen-tts` and
+`qwen-codec` are included in the same image at `/app/`.
+
+```
+docker run --rm -p 8080:8080 \
+    -v /path/to/models:/models:ro \
+    -e MODEL_PATH=/models/qwen-talker-1.7b-base-Q8_0.gguf \
+    -e CODEC_PATH=/models/qwen-tokenizer-12hz-Q8_0.gguf \
+    ghcr.io/serveurpersocom/qwentts.cpp:cpu
+```
+
+CUDA image, with GPU access and a directory of reference WAVs to
+auto-register as cloned voices on startup:
+
+```
+docker run --rm --gpus all -p 8080:8080 \
+    -v /path/to/models:/models:ro \
+    -v /path/to/voices:/voices:ro \
+    -e MODEL_PATH=/models/qwen-talker-1.7b-base-Q8_0.gguf \
+    -e CODEC_PATH=/models/qwen-tokenizer-12hz-Q8_0.gguf \
+    ghcr.io/serveurpersocom/qwentts.cpp:cuda
+```
+
+## Entrypoint environment variables
+
+| Variable          | Default                                    |
+|--------------------|---------------------------------------------|
+| `MODEL_PATH`       | `/models/qwen-talker-1.7b-base-Q8_0.gguf`    |
+| `CODEC_PATH`       | `/models/qwen-tokenizer-12hz-Q8_0.gguf`      |
+| `TTS_LANG`         | `auto`                                       |
+| `HOST`             | `0.0.0.0`                                    |
+| `PORT`             | `8080`                                       |
+| `MODEL_ALIAS`      | unset (reports the GGUF file name)           |
+| `CODEC_CHUNK_DUR`  | unset (server default: `24.0`)               |
+| `CODEC_LEFT_DUR`   | unset (server default: `2.0`)                 |
+| `MAX_BATCH`        | unset (server default: `1`)                  |
+| `NO_FA`            | unset; set to `1` to disable flash attention  |
+| `CLAMP_FP16`       | unset; set to `1` to clamp hidden states      |
+
+Every `*.wav` placed in `/voices` is registered as a cloned voice
+under its filename stem (e.g. `/voices/freeman.wav` -> voice
+`freeman`) once `/health` responds.
+
+## Building locally
+
+```
+git clone --recurse-submodules https://github.com/ServeurpersoCom/qwentts.cpp.git
+cd qwentts.cpp
+docker build --target cpu  -t qwentts.cpp:cpu  .
+docker build --target cuda -t qwentts.cpp:cuda .
+```
+
+`--target` is required to pick a variant; without it, `docker build`
+uses the last stage in the `Dockerfile` (`cuda`).
+
+### Older GPUs (Pascal / sm_61 and similar)
+
+`docker build` never has GPU device access (unlike `docker run
+--gpus`), so CMake's CUDA-architecture autodetection has nothing to
+detect against. This project's own `CMakeLists.txt` already handles
+that by defaulting `CMAKE_CUDA_ARCHITECTURES` to a fixed Turing-and-newer
+list (`75-virtual;80-virtual;86-real;89-real`, plus Blackwell with CUDA
+12.8+) when the variable isn't set — which is exactly right for
+distributing a single image across modern GPUs, but does not cover
+Pascal (sm_61) or older. Building for one of those requires passing the
+architecture explicitly:
+
+```
+docker build --target cuda -t qwentts.cpp:cuda \
+    --build-arg CMAKE_CUDA_ARCHITECTURES=61 .
+```
+
+Find your GPU's compute capability at
+https://developer.nvidia.com/cuda-gpus.
+
+### CUDA driver stub at link time
+
+The CUDA build links against `libcuda.so` (the driver API, used by
+ggml's VMM pool allocator) at build time even though no driver is
+present. The `Dockerfile` already points the linker at the devel
+image's `lib64/stubs/libcuda.so` for this; it's mentioned here only in
+case you customize `CUDA_BUILD_IMAGE` to a base that ships that stub
+somewhere else.

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -73,21 +73,21 @@ docker build --target vulkan -t qwentts.cpp:vulkan .
 `--target` is required to pick a variant; without it, `docker build`
 uses the last stage in the `Dockerfile` (`cuda`).
 
-### Older GPUs (Pascal / sm_61 and similar)
+### Older GPUs (pre-Pascal)
 
 `docker build` never has GPU device access (unlike `docker run
 --gpus`), so CMake's CUDA-architecture autodetection has nothing to
 detect against. This project's own `CMakeLists.txt` already handles
-that by defaulting `CMAKE_CUDA_ARCHITECTURES` to a fixed Turing-and-newer
-list (`75-virtual;80-virtual;86-real;89-real`, plus Blackwell with CUDA
-12.8+) when the variable isn't set — which is exactly right for
-distributing a single image across modern GPUs, but does not cover
-Pascal (sm_61) or older. Building for one of those requires passing the
-architecture explicitly:
+that by defaulting `CMAKE_CUDA_ARCHITECTURES` to a fixed Pascal-and-newer
+list (`61-real;75-virtual;80-virtual;86-real;89-real`, plus Blackwell
+with CUDA 12.8+) when the variable isn't set, so Pascal cards (sm_61,
+e.g. the GTX 10-series) work out of the box with no override. GPUs
+older than Pascal (Maxwell and earlier) still need the architecture
+passed explicitly:
 
 ```
 docker build --target cuda -t qwentts.cpp:cuda \
-    --build-arg CMAKE_CUDA_ARCHITECTURES=61 .
+    --build-arg CMAKE_CUDA_ARCHITECTURES=50 .   # Maxwell
 ```
 
 Find your GPU's compute capability at

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -1,9 +1,9 @@
 # Docker
 
-Pre-built images: `ghcr.io/serveurpersocom/qwentts.cpp:cpu` and
-`ghcr.io/serveurpersocom/qwentts.cpp:cuda` (also tagged per release,
-e.g. `:cuda-v1.2.3`). Both run `tts-server`; `qwen-tts` and
-`qwen-codec` are included in the same image at `/app/`.
+Pre-built images: `ghcr.io/serveurpersocom/qwentts.cpp:cpu`,
+`:cuda` and `:vulkan` (also tagged per release, e.g. `:cuda-v1.2.3`).
+All three run `tts-server`; `qwen-tts` and `qwen-codec` are included in
+the same image at `/app/`.
 
 ```
 docker run --rm -p 8080:8080 \
@@ -24,6 +24,21 @@ docker run --rm --gpus all -p 8080:8080 \
     -e CODEC_PATH=/models/qwen-tokenizer-12hz-Q8_0.gguf \
     ghcr.io/serveurpersocom/qwentts.cpp:cuda
 ```
+
+Vulkan image (AMD/Intel GPUs), passing through the DRI device node:
+
+```
+docker run --rm --device /dev/dri -p 8080:8080 \
+    -v /path/to/models:/models:ro \
+    -e MODEL_PATH=/models/qwen-talker-1.7b-base-Q8_0.gguf \
+    -e CODEC_PATH=/models/qwen-tokenizer-12hz-Q8_0.gguf \
+    ghcr.io/serveurpersocom/qwentts.cpp:vulkan
+```
+
+The `:vulkan` image bundles Mesa's Vulkan drivers (AMD/Intel). On an
+NVIDIA GPU, prefer `:cuda`; running `:vulkan` there would additionally
+need the host's proprietary NVIDIA Vulkan ICD mounted in, which the
+image does not provide.
 
 ## Entrypoint environment variables
 
@@ -50,8 +65,9 @@ under its filename stem (e.g. `/voices/freeman.wav` -> voice
 ```
 git clone --recurse-submodules https://github.com/ServeurpersoCom/qwentts.cpp.git
 cd qwentts.cpp
-docker build --target cpu  -t qwentts.cpp:cpu  .
-docker build --target cuda -t qwentts.cpp:cuda .
+docker build --target cpu    -t qwentts.cpp:cpu    .
+docker build --target cuda   -t qwentts.cpp:cuda   .
+docker build --target vulkan -t qwentts.cpp:vulkan .
 ```
 
 `--target` is required to pick a variant; without it, `docker build`


### PR DESCRIPTION
## Summary

Adds a multi-stage `Dockerfile` with three build targets (`cpu`, `cuda`, `vulkan`), a generic `docker/entrypoint.sh`, `docs/DOCKER.md`, and a GitHub Actions workflow that builds and publishes images to GHCR (`ghcr.io/serveurpersocom/qwentts.cpp:{cpu,cuda,vulkan}`) on pushes to `master` and on version tags, and validates the build (without pushing) on PRs that touch these files. Also adds Pascal (sm_61) to `CMakeLists.txt`'s default `CMAKE_CUDA_ARCHITECTURES` so Pascal cards (GTX 10-series) build with no override needed, including through the new `cuda` Docker target.

```
docker build --target cpu    -t qwentts.cpp:cpu    .
docker build --target cuda   -t qwentts.cpp:cuda   .
docker build --target vulkan -t qwentts.cpp:vulkan .
```

## Why

There's currently no supported way to get a pre-built image, so anyone wanting to run `tts-server` in a container has to work out the whole toolchain themselves. We ran into two `docker build`-specific gotchas doing this for our own deployment (documented as comments in the Dockerfile and in `docs/DOCKER.md`):

- `docker build` never has GPU device access (unlike `docker run --gpus`), so CMake's CUDA-arch autodetection has nothing to detect against. GPUs outside this project's own default arch list need an explicit `--build-arg CMAKE_CUDA_ARCHITECTURES=<arch>` when building without a GPU present.
- ggml's CUDA VMM pool allocator needs driver-API symbols (`cuMemCreate`, `cuMemMap`, ...) at link time, but the real `libcuda.so` isn't present in a build without a GPU. The devel image ships a link-time-only stub at `lib64/stubs/libcuda.so` for exactly this; it just needs an explicit `-L`/`-lcuda`.

While verifying this on our own deployment box (a GTX 1070, Pascal/sm_61), we needed `--build-arg CMAKE_CUDA_ARCHITECTURES=61` since Pascal isn't in the project's default arch list. Since the fix is a one-line, low-risk addition to that default list (`61-real`, SASS-only, no virtual/PTX baseline change), we included it here rather than making every Pascal user pass a build-arg forever.

The Vulkan target uses the LunarG SDK apt repo for `glslc` (ggml-vulkan's shader compiler), since Ubuntu 22.04's own repos don't package it.

## Test plan

All verified end-to-end on our own deployment box (GTX 1070, Pascal/sm_61), stopping/restarting the production container around each GPU test to free VRAM:

- [x] `cpu`: builds clean, `docker run` with real GGUF models loads and serves; `/health` OK; real synthesis via `POST /v1/audio/speech` produces a valid 24kHz mono WAV
- [x] `cuda`, **with no `--build-arg` override** (exercising the new default arch list): builds clean, `docker run --gpus all` loads the model onto the GPU (confirmed via container logs: correct architecture picked up, CUDA graphs correctly disabled for it), `/health` OK, real GPU synthesis produces a valid WAV
- [x] `vulkan`: builds clean; binary runs and resolves its shared libraries correctly (`--help` exits 0). Not exercised against an actual Vulkan device — this box only has an NVIDIA GPU, for which `:cuda` is the intended target; the image is meant for AMD/Intel GPUs (Mesa Vulkan drivers)
- [x] Confirmed via `git diff` that the final squashed commit tree is byte-identical to the original (unsquashed) working state — the history cleanup didn't change anything

Not yet exercised: the GitHub Actions workflow itself hasn't run in CI (new workflow files don't trigger via `pull_request` until merged to the default branch — a GitHub platform limitation, not something in this PR).