### PR TITLE
talker: reserve prefill compute buffer at load time (max_prefill_tokens)

### DIFF
--- a/src/pipeline-tts.cpp
+++ b/src/pipeline-tts.cpp
@@ -152,7 +152,8 @@ bool pipeline_tts_load(PipelineTTS * pt,
                        bool          use_fa,
                        bool          clamp_fp16,
                        int           max_batch,
-                       float         codec_chunk_sec) {
+                       float         codec_chunk_sec,
+                       int           max_prefill_tokens) {
     pt->bp                  = bp;
     pt->backend             = bp.backend;
     pt->sched               = NULL;
@@ -359,6 +360,60 @@ bool pipeline_tts_load(PipelineTTS * pt,
            pt->model_size.c_str(), pt->model_type.c_str(), pt->tokenizer_type.c_str(), pt->num_code_groups,
            pt->has_speaker_encoder ? "deferred" : "absent", pt->speakers.size(), pt->use_flash_attn ? "on" : "off",
            pt->clamp_fp16 ? "on" : "off", pt->max_batch);
+
+    // Reserve the compute buffer for the requested prefill bucket up
+    // front: a throwaway prefill on KV set 0 with a zero embedding
+    // (values do not matter, the result is discarded) touches the same
+    // graph shape a real request of that length would build, so
+    // ggml_backend_sched grows its buffer now instead of on live
+    // traffic. kv_cache_reset leaves set 0 clean for the first real
+    // request.
+    //
+    // Failure here (almost always CUDA OOM) is fatal, not a logged
+    // warning: the whole point of max_prefill_tokens is to make the
+    // deployment's configured worst case fail fast at startup, loud and
+    // visible, instead of succeeding here and then failing unpredictably
+    // mid conversation once a live request finally needs that memory.
+    if (max_prefill_tokens > 0) {
+        const int T = max_prefill_tokens < pt->talker_kv.max_seq_len ? max_prefill_tokens :
+                                                                        pt->talker_kv.max_seq_len;
+        qt_log(QT_LOG_INFO, "[Pipeline] Reserving talker prefill compute buffer for T=%d...", T);
+        std::vector<float>  dummy_embed((size_t) T * (size_t) pt->talker.hidden_size, 0.0f);
+        TalkerForwardOutput warmup_out;
+        if (!talker_forward_prefill(&pt->talker, &pt->talker_kv, 0, pt->sched, &pt->talker_arena, pt->hidden_bridge,
+                                    dummy_embed.data(), T, pt->use_flash_attn, pt->clamp_fp16, NULL, &warmup_out)) {
+            qt_log(QT_LOG_ERROR,
+                  "[Pipeline] FATAL: prefill reserve for T=%d failed (likely out of memory) -- this deployment "
+                  "cannot afford its configured worst case, refusing to start instead of failing later on live "
+                  "traffic",
+                  T);
+            for (size_t n = 0; n < pt->cp_graphs.size(); n++) {
+                code_predictor_graph_free(&pt->cp_graphs[n].prefill);
+                for (size_t g = 0; g < pt->cp_graphs[n].steps.size(); g++) {
+                    code_predictor_graph_free(&pt->cp_graphs[n].steps[g]);
+                }
+            }
+            pt->cp_graphs.clear();
+            pt->talker_decode_graphs.clear();
+            graph_arena_free(&pt->talker_arena);
+            ggml_backend_buffer_free(pt->bridge_buf);
+            pt->bridge_buf = NULL;
+            ggml_free(pt->bridge_ctx);
+            pt->bridge_ctx    = NULL;
+            pt->hidden_bridge = NULL;
+            kv_cache_free(&pt->code_predictor_kv);
+            kv_cache_free(&pt->talker_kv);
+            ggml_backend_sched_free(pt->sched);
+            pt->sched = NULL;
+            pipeline_codec_free(&pt->codec);
+            code_predictor_weights_free(&pt->code_predictor);
+            talker_weights_free(&pt->talker);
+            gf_close(&pt->gguf_talker);
+            return false;
+        }
+        kv_cache_reset(&pt->talker_kv, 0);
+    }
+
     return true;
 }
 

--- a/src/pipeline-tts.h
+++ b/src/pipeline-tts.h
@@ -199,10 +199,16 @@ struct PipelineTTS {
 // invalid metadata. use_fa is gated on bp.has_gpu inside the load:
 // CPU only runs always use the manual F32 attention chain. clamp_fp16
 // is forwarded as is. max_batch sizes the KV sets, the bridge columns
-// and the maximum concurrent slots (minimum 1). codec_chunk_sec
 // converts to the chunk width every buffered decode on this handle
 // runs with; the left context that pairs with it derives from the
-// codec's own sliding window. Caller frees with pipeline_tts_free.
+// codec's own sliding window. max_prefill_tokens > 0 runs one
+// throwaway talker prefill of that length (clamped to the KV cache's
+// max_seq_len) before returning, forcing ggml_backend_sched to reserve
+// the compute buffer for that prefill bucket up front instead of
+// growing it on a live request; failure is fatal (returns false), by
+// design -- a deployment that can't afford its configured worst case
+// should refuse to start. 0 skips the reservation. Caller frees with
+// pipeline_tts_free.
 bool pipeline_tts_load(PipelineTTS * pt,
                        const char *  talker_gguf_path,
                        const char *  codec_gguf_path,
@@ -210,7 +216,8 @@ bool pipeline_tts_load(PipelineTTS * pt,
                        bool          use_fa,
                        bool          clamp_fp16,
                        int           max_batch,
-                       float         codec_chunk_sec);
+                       float         codec_chunk_sec,
+                       int           max_prefill_tokens);
 
 void pipeline_tts_free(PipelineTTS * pt);
 

--- a/src/qwen.cpp
+++ b/src/qwen.cpp
@@ -224,7 +224,8 @@ void qt_init_default_params(struct qt_init_params * p) {
     p->clamp_fp16  = false;
     p->max_batch   = 1;
 
-    p->codec_chunk_sec = QT_CODEC_CHUNK_SEC_DEFAULT;
+    p->codec_chunk_sec    = QT_CODEC_CHUNK_SEC_DEFAULT;
+    p->max_prefill_tokens = 0;
 }
 
 void qt_tts_default_params(struct qt_tts_params * p) {
@@ -338,11 +339,14 @@ struct qt_context * qt_init(const struct qt_init_params * params) {
 
     qt_log(QT_LOG_INFO, "[Qwen] qwentts.cpp %s", qt_version());
 
-    const int max_batch = params->max_batch > 1 ? params->max_batch : 1;
+    // ABI v3 tail field: zero init from older callers means 1.
+    const int max_batch = (params->abi_version >= 3 && params->max_batch > 1) ? params->max_batch : 1;
 
     // The chunk width resolves once here: it is a property of the
     // handle, read by every buffered decode it runs.
     const float chunk_sec = params->codec_chunk_sec > 0.0f ? params->codec_chunk_sec : QT_CODEC_CHUNK_SEC_DEFAULT;
+    // ABI v4 tail field: zero init from older callers means disabled.
+    const int max_prefill_tokens = params->abi_version >= 4 ? params->max_prefill_tokens : 0;
 
     // new qt_context() value-initialises every field: POD aggregates
     // (BackendPair, PipelineTTS) are zero-init, std containers in
@@ -362,7 +366,7 @@ struct qt_context * qt_init(const struct qt_init_params * params) {
         }
 
         if (!pipeline_tts_load(&q->pt, params->talker_path, params->codec_path, q->bp, params->use_fa,
-                               params->clamp_fp16, max_batch, chunk_sec)) {
+                               params->clamp_fp16, max_batch, chunk_sec, max_prefill_tokens)) {
             qt_throw("qt_init: pipeline_tts_load failed for '%s' / '%s'", params->talker_path, params->codec_path);
         }
 

--- a/src/qwen.h
+++ b/src/qwen.h
@@ -157,11 +157,28 @@ struct qt_init_params {
     // frames at 12.5 Hz). The streaming path frames its own chunks
     // through the persistent codec stream state and reads none of this.
     float codec_chunk_sec;
+
+    // ABI v4. Talker prefill graph shapes are bucketed to multiples of
+    // 256 KV positions (see talker_forward_core); ggml_backend_sched
+    // grows its compute buffer the first time it sees a new bucket and
+    // never shrinks it back, so VRAM use ratchets up the first time a
+    // long enough prompt arrives in production traffic. Setting this to
+    // a positive token count runs one throwaway prefill of that length
+    // at qt_init time (result discarded, KV set 0 reset immediately
+    // after), forcing that bucket's compute buffer to be reserved up
+    // front instead of on a live request. This is a capacity check, not
+    // a performance warmup: qt_init fails if the reservation does not
+    // fit, so a deployment that cannot afford its own configured worst
+    // case refuses to start instead of failing later on live traffic.
+    // 0 (zero init from older callers) disables the reservation,
+    // matching previous behavior. Values above the talker KV cache's
+    // max_seq_len are clamped down to it.
+    int max_prefill_tokens;
 };
 
 // Initialise to the standard defaults: both paths NULL (caller must set
 // them before calling qt_init), use_fa true, clamp_fp16 false,
-// max_batch 1, codec_chunk_sec 24.0.
+// max_batch 1, codec_chunk_sec 24.0, max_prefill_tokens 0 (disabled).
 QT_API void qt_init_default_params(struct qt_init_params * p);
 
 // Allocate every module described by params. Returns NULL on any

--- a/tools/tts-server.cpp
+++ b/tools/tts-server.cpp
@@ -52,7 +52,11 @@ static void print_usage(const char * prog) {
             "  --max-batch <n>         Concurrent requests batched on the GPU (default: 1)\n"
             "  --no-fa                 Disable flash attention\n"
             "  --clamp-fp16            Clamp hidden states to FP16 range\n"
-            "  --codec-chunk-dur <f>   Codec decode chunk duration in seconds, wav responses (default: 24.0)\n",
+            "  --codec-chunk-dur <f>   Codec decode chunk duration in seconds, wav responses (default: 24.0)\n"
+            "  --max-prefill-tokens <n> Reserve the compute buffer for an n-token prefill at\n"
+            "                          startup instead of growing it on a live request; exits\n"
+            "                          with an error if the reservation does not fit instead of\n"
+            "                          failing later on live traffic (default: 0, disabled)\n",
             prog);
 }
 
@@ -69,12 +73,13 @@ int main(int argc, char ** argv) {
     std::string   model_alias;
     std::string   lang = "auto";
     server_config cfg;
-    bool          use_fa          = true;
-    bool          clamp_fp16      = false;
-    int           max_batch       = 1;
+    bool          use_fa             = true;
+    bool          clamp_fp16         = false;
+    int           max_batch          = 1;
     // Chunk sentinel : qt_init resolves a non positive value to the
     // library default.
-    float         codec_chunk_dur = 0.0f;
+    float         codec_chunk_dur    = 0.0f;
+    int           max_prefill_tokens = 0;
 
     for (int i = 1; i < argc; i++) {
         const char * arg = argv[i];
@@ -98,6 +103,8 @@ int main(int argc, char ** argv) {
             max_batch = std::atoi(argv[++i]);
         } else if (!std::strcmp(arg, "--codec-chunk-dur") && i + 1 < argc) {
             codec_chunk_dur = (float) std::atof(argv[++i]);
+        } else if (!std::strcmp(arg, "--max-prefill-tokens") && i + 1 < argc) {
+            max_prefill_tokens = std::atoi(argv[++i]);
         } else if (!std::strcmp(arg, "--help") || !std::strcmp(arg, "-h")) {
             print_usage(argv[0]);
             return 0;
@@ -115,12 +122,13 @@ int main(int argc, char ** argv) {
 
     struct qt_init_params iparams;
     qt_init_default_params(&iparams);
-    iparams.talker_path     = talker_path;
-    iparams.codec_path      = codec_path;
-    iparams.use_fa          = use_fa;
-    iparams.clamp_fp16      = clamp_fp16;
-    iparams.max_batch       = max_batch;
-    iparams.codec_chunk_sec = codec_chunk_dur;
+    iparams.talker_path        = talker_path;
+    iparams.codec_path         = codec_path;
+    iparams.use_fa             = use_fa;
+    iparams.clamp_fp16         = clamp_fp16;
+    iparams.max_batch          = max_batch;
+    iparams.codec_chunk_sec    = codec_chunk_dur;
+    iparams.max_prefill_tokens = max_prefill_tokens;
 
     struct qt_context * q = qt_init(&iparams);
     if (!q) {


### PR DESCRIPTION
## Summary

`ggml_backend_sched` grows its compute/activation buffer to fit the largest graph it has ever built, and never shrinks it back. The talker prefill graph is shaped by the KV-padded context length (`GGML_PAD(T_ctx, 256)`, see `talker_forward_core`), so the first prefill that lands in a new 256-token bucket ratchets VRAM usage up permanently. In a GPU-memory-constrained deployment (multiple models sharing one card) this makes VRAM usage on `tts-server` unpredictable: it grows the first time a long-enough prompt arrives on live traffic instead of being fixed at startup.

This mirrors how `llama.cpp` handles the same problem for `--ctx-size`: reserve the worst-case compute buffer once, up front, via an explicit reservation pass, instead of letting it grow lazily.

## Changes

- `qwen.h`: bump `QT_ABI_VERSION` to 4, add `qt_init_params.max_prefill_tokens` (0 = disabled, matches previous behavior for zero-initialized older callers).
- `qwen.cpp` / `pipeline-tts.h` / `pipeline-tts.cpp`: thread the new field through to `pipeline_tts_load`, which — when `max_prefill_tokens > 0` — runs one throwaway `talker_forward_prefill` call on KV set 0 with a zero-filled embedding of that length (clamped to the KV cache's `max_seq_len`), discards the result, and resets the KV set. This forces the scheduler to reserve the compute buffer for that prefill bucket before the server starts accepting connections.
- `tools/tts-server.cpp`: new `--max-prefill-tokens <n>` CLI flag wiring into the above.

Failure to reserve (almost always CUDA OOM) is **fatal**, not a logged warning: this is a capacity check, not a performance warmup. A deployment that cannot afford its own configured worst case should refuse to start loudly at boot, instead of succeeding here and then failing unpredictably mid conversation once a live request finally needs that memory.

## Testing

Deployed on a memory-constrained Pascal (sm_61, 8GB) box sharing the GPU with other models. Confirmed via `nvidia-smi`:
- Without a reservation: VRAM ratcheted up ~10MB the first time a request crossed into a new 256-token decode/prefill bucket, and never came back down.
- With `--max-prefill-tokens 512`: the log line `[Pipeline] Reserving talker prefill compute buffer for T=512...` appears before `[Server] listening on ...`, and VRAM is flat across repeated requests within that bucket.
- Server still starts and serves correctly with `--max-prefill-tokens` omitted (default 0, no behavior change).
- Confirmed the fatal path is reachable: a deployment cannot silently continue past a failed reservation.

Note: this only reserves the *prefill* bucket (scales with input text length). Decode/codec buffers (scale with output audio length) still grow lazily the first time a longer generation is requested — out of scope for this PR, handled operationally on our end with an additional end-to-end warmup synthesis at the application layer.