### PR TITLE
ci: lowercase the GHCR image repository path

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,7 +42,7 @@ jobs:
         id: tags
         shell: bash
         run: |
-          image="ghcr.io/${{ github.repository }}"
+          image="ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')"
           variant="${{ matrix.variant }}"
           tags="${image}:${variant}-${{ github.sha }}"
           if [ "${{ github.ref }}" = "refs/heads/master" ]; then


### PR DESCRIPTION
## Problem
The master branch Docker workflow (added in #15) fails on every push:

    ERROR: failed to build: invalid tag "ghcr.io/ServeurpersoCom/qwentts.cpp:cpu-978fc08f5a125369c160b2d7dc99a85be1092f26": repository name must be lowercase

`github.repository` preserves the owner login's mixed case (`ServeurpersoCom`), but GHCR/OCI repository names must be all lowercase.

## Fix
Lowercase the computed image path before building the tag list.

## Test plan
- [ ] CI run on this PR builds/pushes (dry-run on PR event, no push) without the tag error