### PR TITLE
Replace fprintf with qt_log across all library sources

### DIFF
--- a/src/audio-io.h
+++ b/src/audio-io.h
@@ -7,7 +7,6 @@
 
 #include <cmath>
 #include <cstdint>
-#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <string>
@@ -17,6 +16,9 @@
 #    include <fcntl.h>
 #    include <io.h>
 #endif
+
+// qt-error.h: qt_log routing
+#include "qt-error.h"
 
 // wav.h: WAV reader (returns interleaved, we deinterleave below)
 #include "wav.h"
@@ -32,7 +34,7 @@ static uint8_t * audio_io_load_file(const char * path, size_t * size_out) {
     *size_out = 0;
     FILE * fp = utf8_fopen(path, "rb");
     if (!fp) {
-        fprintf(stderr, "[Audio] Cannot open %s\n", path);
+        qt_log(QT_LOG_ERROR, "[Audio] Cannot open %s", path);
         return NULL;
     }
     fseek(fp, 0, SEEK_END);
@@ -105,16 +107,16 @@ static float * audio_mono_from_planar(float * raw, int T, int sr, int target_sr,
     float * stereo_rs = raw;
     int     T_rs      = T;
     if (sr != target_sr) {
-        fprintf(stderr, "[Audio-Resample] %d Hz -> %d Hz, %d samples...\n", sr, target_sr, T);
+        qt_log(QT_LOG_INFO, "[Audio-Resample] %d Hz -> %d Hz, %d samples...", sr, target_sr, T);
         int     T_new     = 0;
         float * resampled = audio_resample(raw, T, sr, target_sr, 2, &T_new);
         free(raw);
         if (!resampled) {
-            fprintf(stderr, "[Audio-Resample] Resample failed\n");
+            qt_log(QT_LOG_ERROR, "[Audio-Resample] Resample failed");
             *T_out = 0;
             return NULL;
         }
-        fprintf(stderr, "[Audio-Resample] Done: %d -> %d samples\n", T, T_new);
+        qt_log(QT_LOG_INFO, "[Audio-Resample] Done: %d -> %d samples", T, T_new);
         stereo_rs = resampled;
         T_rs      = T_new;
     }
@@ -324,7 +326,7 @@ static std::string audio_encode_wav(const float * audio, int T_audio, int sr, Wa
         case WAV_F32:
             return audio_encode_wav_f32(audio, T_audio, sr);
     }
-    fprintf(stderr, "[WAV] unknown format %d\n", (int) fmt);
+    qt_log(QT_LOG_WARN, "[WAV] unknown format %d", (int) fmt);
     return {};
 }
 
@@ -338,18 +340,18 @@ static bool audio_write_wav(const char * path, const float * audio, int T_audio,
 
     FILE * fp = utf8_fopen(path, "wb");
     if (!fp) {
-        fprintf(stderr, "[WAV] Cannot open %s for writing\n", path);
+        qt_log(QT_LOG_ERROR, "[WAV] Cannot open %s for writing", path);
         return false;
     }
     if (fwrite(wav.data(), 1, wav.size(), fp) != wav.size()) {
-        fprintf(stderr, "[WAV] Failed to write %s\n", path);
+        qt_log(QT_LOG_ERROR, "[WAV] Failed to write %s", path);
         fclose(fp);
         return false;
     }
     fclose(fp);
 
     const char * fmt_name = (fmt == WAV_S16) ? "S16" : (fmt == WAV_S24) ? "S24" : "F32";
-    fprintf(stderr, "[WAV] Wrote %s: %d samples, %d Hz, mono %s\n", path, T_audio, sr, fmt_name);
+    qt_log(QT_LOG_INFO, "[WAV] Wrote %s: %d samples, %d Hz, mono %s", path, T_audio, sr, fmt_name);
     return true;
 }
 
@@ -403,7 +405,7 @@ static bool wav_stream_write_header(wav_stream * ws) {
     wav_write_u32le(p, data_size);
 
     if (fwrite(header, 1, 44, ws->fp) != 44) {
-        fprintf(stderr, "[WAV-Stream] header write failed\n");
+        qt_log(QT_LOG_ERROR, "[WAV-Stream] header write failed");
         return false;
     }
     fflush(ws->fp);
@@ -426,7 +428,7 @@ static bool wav_stream_open_stdout(wav_stream * ws, int sr, WavFormat fmt) {
     }
 
     const char * fmt_name = (fmt == WAV_S16) ? "S16" : (fmt == WAV_S24) ? "S24" : "F32";
-    fprintf(stderr, "[WAV-Stream] stdout: %d Hz, mono %s\n", sr, fmt_name);
+    qt_log(QT_LOG_INFO, "[WAV-Stream] stdout: %d Hz, mono %s", sr, fmt_name);
     return true;
 }
 

--- a/src/audio-resample.h
+++ b/src/audio-resample.h
@@ -20,8 +20,9 @@
 //
 // Apply: pad (width, width + orig), strided conv1d, transpose, truncate.
 
+#include "qt-error.h"
+
 #include <cmath>
-#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <vector>
@@ -136,7 +137,7 @@ static float * audio_resample(const float * in, int n_in, int sr_in, int sr_out,
         size_t  sz  = (size_t) n_in * (size_t) nch * sizeof(float);
         float * out = (float *) malloc(sz);
         if (!out) {
-            fprintf(stderr, "[Audio-Resample] OOM passthrough buffer (%zu bytes)\n", sz);
+            qt_log(QT_LOG_ERROR, "[Audio-Resample] OOM passthrough buffer (%zu bytes)", sz);
             *n_out = 0;
             return NULL;
         }
@@ -162,7 +163,7 @@ static float * audio_resample(const float * in, int n_in, int sr_in, int sr_out,
 
     float * out = (float *) malloc((size_t) target * (size_t) nch * sizeof(float));
     if (!out) {
-        fprintf(stderr, "[Audio-Resample] OOM output buffer\n");
+        qt_log(QT_LOG_ERROR, "[Audio-Resample] OOM output buffer");
         *n_out = 0;
         return NULL;
     }

--- a/src/backend.h
+++ b/src/backend.h
@@ -11,7 +11,6 @@
 #include "ggml-backend.h"
 #include "qt-error.h"
 
-#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <string>
@@ -80,14 +79,13 @@ static void qt_ggml_log(enum ggml_log_level level, const char * text, void * use
     }
 
     if (count > 1) {
-        fprintf(stderr, "[Dedup] Previous line repeated %d times total\n", count);
+        qt_log(QT_LOG_DEBUG, "[Dedup] Previous line repeated %d times total", count);
     }
 
-    fputs(text, stderr);
+    qt_log(QT_LOG_DEBUG, "%s", text);
     strncpy(last, text, sizeof(last) - 1);
     last[sizeof(last) - 1] = 0;
     count                  = 1;
-    fflush(stderr);
 }
 
 static BackendPair backend_init(const char * label) {

--- a/src/bpe.h
+++ b/src/bpe.h
@@ -11,10 +11,10 @@
 // such as TTS style markers and language tags).
 
 #include "gguf.h"
+#include "qt-error.h"
 
 #include <cassert>
 #include <climits>
-#include <cstdio>
 #include <cstring>
 #include <string>
 #include <unordered_map>
@@ -410,14 +410,14 @@ static bool load_bpe_from_gguf(BPETokenizer * tok, const char * gguf_path) {
     struct gguf_init_params gp  = { true, NULL };
     struct gguf_context *   ctx = gguf_init_from_file(gguf_path, gp);
     if (!ctx) {
-        fprintf(stderr, "[BPE] Failed to open %s\n", gguf_path);
+        qt_log(QT_LOG_ERROR, "[BPE] Failed to open %s", gguf_path);
         return false;
     }
 
     int64_t tok_key = gguf_find_key(ctx, "tokenizer.ggml.tokens");
     int64_t mrg_key = gguf_find_key(ctx, "tokenizer.ggml.merges");
     if (tok_key < 0 || mrg_key < 0) {
-        fprintf(stderr, "[BPE] Tokenizer not found in %s\n", gguf_path);
+        qt_log(QT_LOG_ERROR, "[BPE] Tokenizer not found in %s", gguf_path);
         gguf_free(ctx);
         return false;
     }
@@ -454,7 +454,7 @@ static bool load_bpe_from_gguf(BPETokenizer * tok, const char * gguf_path) {
         bpe_add_special(tok, "<|endoftext|>", tok->eos_id);
     }
 
-    fprintf(stderr, "[BPE] Loaded from GGUF: %d vocab, %d merges, eos_id=%d\n", tok->n_vocab, n_merges, tok->eos_id);
+    qt_log(QT_LOG_INFO, "[BPE] Loaded from GGUF: %d vocab, %d merges, eos_id=%d", tok->n_vocab, n_merges, tok->eos_id);
     return true;
 }
 
@@ -469,7 +469,7 @@ static bool bpe_load_specials_from_keys(BPETokenizer *       tok,
     struct gguf_init_params gp  = { true, NULL };
     struct gguf_context *   ctx = gguf_init_from_file(gguf_path, gp);
     if (!ctx) {
-        fprintf(stderr, "[BPE] Failed to open %s for specials\n", gguf_path);
+        qt_log(QT_LOG_ERROR, "[BPE] Failed to open %s for specials", gguf_path);
         return false;
     }
 
@@ -477,17 +477,17 @@ static bool bpe_load_specials_from_keys(BPETokenizer *       tok,
     for (int i = 0; i < n_keys; i++) {
         int64_t k = gguf_find_key(ctx, keys[i]);
         if (k < 0) {
-            fprintf(stderr, "[BPE] WARNING: missing %s in GGUF\n", keys[i]);
+            qt_log(QT_LOG_WARN, "[BPE] WARNING: missing %s in GGUF", keys[i]);
             continue;
         }
         int id = (int) gguf_get_val_u32(ctx, k);
         if (id < 0 || id >= tok->n_vocab) {
-            fprintf(stderr, "[BPE] WARNING: %s id=%d out of vocab range\n", keys[i], id);
+            qt_log(QT_LOG_WARN, "[BPE] WARNING: %s id=%d out of vocab range", keys[i], id);
             continue;
         }
         const std::string & s = tok->id_to_str[id];
         if (s.empty()) {
-            fprintf(stderr, "[BPE] WARNING: %s id=%d has empty vocab string\n", keys[i], id);
+            qt_log(QT_LOG_WARN, "[BPE] WARNING: %s id=%d has empty vocab string", keys[i], id);
             continue;
         }
         bpe_add_special(tok, s, id);
@@ -495,7 +495,7 @@ static bool bpe_load_specials_from_keys(BPETokenizer *       tok,
     }
 
     gguf_free(ctx);
-    fprintf(stderr, "[BPE] Registered %d arch special tokens (total specials=%zu)\n", n_added, tok->specials.size());
+    qt_log(QT_LOG_INFO, "[BPE] Registered %d arch special tokens (total specials=%zu)", n_added, tok->specials.size());
     return true;
 }
 
@@ -569,7 +569,7 @@ static void encode_chunk(const BPETokenizer * tok, const std::string & chunk, st
             ids.push_back(it->second);
         } else {
             // Fallback: encode each byte individually (should not happen with byte-level BPE)
-            fprintf(stderr, "[BPE] WARNING: unknown token '%s'\n", piece.c_str());
+            qt_log(QT_LOG_WARN, "[BPE] WARNING: unknown token '%s'", piece.c_str());
             for (unsigned char c : piece) {
                 auto it2 = tok->vocab.find(std::string(1, c));
                 if (it2 != tok->vocab.end()) {

--- a/src/code-predictor-forward.h
+++ b/src/code-predictor-forward.h
@@ -47,7 +47,6 @@
 
 #include <cmath>
 #include <cstdint>
-#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <vector>
@@ -388,7 +387,7 @@ static bool code_predictor_frame_graph_build(const CodePredictorWeights * cw,
     struct ggml_init_params gp = { bytes, NULL, true };
     cp->ctx                    = ggml_init(gp);
     if (!cp->ctx) {
-        fprintf(stderr, "[CodePredictor] FATAL: frame graph ctx allocation failed\n");
+        qt_log(QT_LOG_ERROR, "[CodePredictor] FATAL: frame graph ctx allocation failed");
         return false;
     }
     struct ggml_cgraph * gf = ggml_new_graph_custom(cp->ctx, max_nodes, false);
@@ -406,7 +405,7 @@ static bool code_predictor_frame_graph_build(const CodePredictorWeights * cw,
 
     cp->galloc = ggml_gallocr_new(ggml_backend_get_default_buffer_type(backend));
     if (!cp->galloc || !ggml_gallocr_alloc_graph(cp->galloc, gf)) {
-        fprintf(stderr, "[CodePredictor] FATAL: frame graph allocation failed\n");
+        qt_log(QT_LOG_ERROR, "[CodePredictor] FATAL: frame graph allocation failed");
         code_predictor_graph_free(cp);
         return false;
     }
@@ -445,7 +444,7 @@ static bool code_predictor_frame_step(const CodePredictorWeights * cw,
     sampler_inputs_upload(sp, temperature, seed, subseq_base, N);
 
     if (ggml_backend_graph_compute(backend, frame_graph->gf) != GGML_STATUS_SUCCESS) {
-        fprintf(stderr, "[CodePredictor] FATAL: frame graph compute failed\n");
+        qt_log(QT_LOG_ERROR, "[CodePredictor] FATAL: frame graph compute failed");
         return false;
     }
 

--- a/src/code-predictor-weights.h
+++ b/src/code-predictor-weights.h
@@ -29,7 +29,6 @@
 #include "weight-ctx.h"
 
 #include <cstdint>
-#include <cstdio>
 #include <cstring>
 #include <string>
 #include <vector>
@@ -79,14 +78,14 @@ static bool code_predictor_weights_load(CodePredictorWeights * cw, const GGUFMod
 
     int num_code_groups = (int) gf_get_u32(gf, "qwen3-tts.num_code_groups");
     if (num_code_groups <= 1) {
-        fprintf(stderr, "[CodePredictor] FATAL: invalid num_code_groups=%d\n", num_code_groups);
+        qt_log(QT_LOG_ERROR, "[CodePredictor] FATAL: invalid num_code_groups=%d", num_code_groups);
         return false;
     }
     cw->num_acoustic_codebooks = num_code_groups - 1;
 
     if (cw->num_hidden_layers <= 0 || cw->hidden_size <= 0) {
-        fprintf(stderr, "[CodePredictor] FATAL: invalid hyperparameters (layers=%d hidden=%d)\n", cw->num_hidden_layers,
-                cw->hidden_size);
+        qt_log(QT_LOG_ERROR, "[CodePredictor] FATAL: invalid hyperparameters (layers=%d hidden=%d)", cw->num_hidden_layers,
+               cw->hidden_size);
         return false;
     }
 
@@ -151,18 +150,18 @@ static bool code_predictor_weights_load(CodePredictorWeights * cw, const GGUFMod
     }
 
     if (!wctx_alloc(&wctx, backend)) {
-        fprintf(stderr, "[CodePredictor] FATAL: backend allocation failed\n");
+        qt_log(QT_LOG_ERROR, "[CodePredictor] FATAL: backend allocation failed");
         return false;
     }
     cw->weight_ctx = wctx.ctx;
     cw->weight_buf = wctx.buffer;
 
-    fprintf(stderr,
-            "[CodePredictor] Loaded: %d layers, hidden %d, heads %d/%d, head_dim %d, "
-            "FFN %d, RoPE theta %.0f, %d acoustic codebooks (vocab %d each), mtp_proj %s\n",
-            cw->num_hidden_layers, cw->hidden_size, cw->num_attention_heads, cw->num_key_value_heads, cw->head_dim,
-            cw->intermediate_size, (double) cw->rope_theta, cw->num_acoustic_codebooks, cw->vocab_size,
-            cw->mtp_proj_w ? "linear" : "identity");
+    qt_log(QT_LOG_INFO,
+           "[CodePredictor] Loaded: %d layers, hidden %d, heads %d/%d, head_dim %d, "
+           "FFN %d, RoPE theta %.0f, %d acoustic codebooks (vocab %d each), mtp_proj %s",
+           cw->num_hidden_layers, cw->hidden_size, cw->num_attention_heads, cw->num_key_value_heads, cw->head_dim,
+           cw->intermediate_size, (double) cw->rope_theta, cw->num_acoustic_codebooks, cw->vocab_size,
+           cw->mtp_proj_w ? "linear" : "identity");
     return true;
 }
 

--- a/src/convnext-block.h
+++ b/src/convnext-block.h
@@ -15,9 +15,9 @@
 #include "ggml-backend.h"
 #include "ggml.h"
 #include "gguf-weights.h"
+#include "qt-error.h"
 #include "weight-ctx.h"
 
-#include <cstdio>
 #include <cstdlib>
 #include <string>
 
@@ -58,7 +58,7 @@ static bool upsample_stage_load(QwenUpsampleStage * stage, const GGUFModel & gf,
     stage->num_blocks     = 2;
 
     if (stage->num_blocks > UPSAMPLE_MAX_BLOCKS) {
-        fprintf(stderr, "[Upsample] FATAL: %d blocks exceeds compile-time max %d\n", stage->num_blocks,
+        qt_log(QT_LOG_ERROR, "[Upsample] FATAL: %d blocks exceeds compile-time max %d", stage->num_blocks,
                 UPSAMPLE_MAX_BLOCKS);
         return false;
     }
@@ -97,16 +97,16 @@ static bool upsample_stage_load(QwenUpsampleStage * stage, const GGUFModel & gf,
     }
 
     if (!wctx_alloc(&wctx, backend)) {
-        fprintf(stderr, "[Upsample] FATAL: backend allocation failed\n");
+        qt_log(QT_LOG_ERROR, "[Upsample] FATAL: backend allocation failed");
         return false;
     }
     stage->weight_ctx = wctx.ctx;
     stage->weight_buf = wctx.buffer;
 
-    fprintf(stderr,
-            "[Upsample] Loaded: %d blocks (%dx ratio per block), channels %d, "
-            "dwconv kernel %d\n",
-            stage->num_blocks, stage->upsample_ratio, stage->channels, stage->dwconv_kernel);
+    qt_log(QT_LOG_INFO,
+           "[Upsample] Loaded: %d blocks (%dx ratio per block), channels %d, "
+           "dwconv kernel %d",
+           stage->num_blocks, stage->upsample_ratio, stage->channels, stage->dwconv_kernel);
     return true;
 }
 

--- a/src/dac-decoder-v2.h
+++ b/src/dac-decoder-v2.h
@@ -30,7 +30,6 @@
 #include "weight-ctx.h"
 
 #include <cmath>
-#include <cstdio>
 #include <cstdlib>
 #include <memory>
 #include <string>
@@ -191,14 +190,14 @@ static bool dac_decoder_load(QwenDACDecoder * d, const GGUFModel & gf, ggml_back
     d->conv_post_b = gf_load_tensor(&wctx, gf, "tok_dec.dec.6.conv.bias");
 
     if (!wctx_alloc(&wctx, backend)) {
-        fprintf(stderr, "[DAC] FATAL: backend allocation failed\n");
+        qt_log(QT_LOG_ERROR, "[DAC] FATAL: backend allocation failed");
         return false;
     }
     d->weight_ctx = wctx.ctx;
     d->weight_buf = wctx.buffer;
 
-    fprintf(stderr, "[DAC] Loaded: %d blocks (strides 8/5/4/3), 24 kHz mono out, weights %.1f MB\n", DAC_NUM_BLOCKS,
-            (float) ggml_backend_buffer_get_size(d->weight_buf) / (1024.0f * 1024.0f));
+    qt_log(QT_LOG_INFO, "[DAC] Loaded: %d blocks (strides 8/5/4/3), 24 kHz mono out, weights %.1f MB", DAC_NUM_BLOCKS,
+           (float) ggml_backend_buffer_get_size(d->weight_buf) / (1024.0f * 1024.0f));
     return true;
 }
 

--- a/src/debug.h
+++ b/src/debug.h
@@ -4,10 +4,10 @@
 // dump.
 // File format: [int32 ndims] [int32 dim0] [int32 dim1] ... [float data...]
 
+#include "qt-error.h"
 #include "utf8.h"
 
 #include <cstdint>
-#include <cstdio>
 #include <vector>
 
 struct DebugDumper {
@@ -37,7 +37,7 @@ static void debug_dump(const DebugDumper * d, const char * name, const float * d
     }
     FILE * f = utf8_fopen(path, "wb");
     if (!f) {
-        fprintf(stderr, "[Debug] cannot write %s\n", path);
+        qt_log(QT_LOG_ERROR, "[Debug] cannot write %s", path);
         return;
     }
     fwrite(&ndims, sizeof(int32_t), 1, f);
@@ -45,16 +45,19 @@ static void debug_dump(const DebugDumper * d, const char * name, const float * d
     fwrite(data, sizeof(float), numel, f);
     fclose(f);
 
-    // First 4 values for quick sanity check on stderr.
-    fprintf(stderr, "[Debug] %s: [", name);
+    // First 4 values for quick sanity check via qt_log.
+    char   shape_str[256];
+    int    shape_pos = 0;
+    shape_pos += snprintf(shape_str + shape_pos, sizeof(shape_str) - (size_t) shape_pos, "[Debug] %s: [", name);
     for (int i = 0; i < ndims; i++) {
-        fprintf(stderr, "%s%d", i ? ", " : "", shape[i]);
+        shape_pos +=
+            snprintf(shape_str + shape_pos, sizeof(shape_str) - (size_t) shape_pos, "%s%d", i ? ", " : "", shape[i]);
     }
-    fprintf(stderr, "] first4:");
+    shape_pos += snprintf(shape_str + shape_pos, sizeof(shape_str) - (size_t) shape_pos, "] first4:");
     for (int i = 0; i < 4 && i < numel; i++) {
-        fprintf(stderr, " %.6f", data[i]);
+        shape_pos += snprintf(shape_str + shape_pos, sizeof(shape_str) - (size_t) shape_pos, " %.6f", data[i]);
     }
-    fprintf(stderr, "\n");
+    qt_log(QT_LOG_DEBUG, "%s", shape_str);
 }
 
 // Convenience: dump 1D tensor [n].

--- a/src/encoder-downsample.h
+++ b/src/encoder-downsample.h
@@ -9,9 +9,9 @@
 #include "ggml-backend.h"
 #include "ggml.h"
 #include "gguf-weights.h"
+#include "qt-error.h"
 #include "weight-ctx.h"
 
-#include <cstdio>
 #include <cstdlib>
 
 struct QwenEncoderDownsample {
@@ -32,7 +32,7 @@ static bool enc_down_load(QwenEncoderDownsample * d, const GGUFModel & gf, ggml_
     wctx_init(&wctx, 4);
     d->weight = gf_load_conv(&wctx, gf, "tok_enc.downsample.weight");
     if (!wctx_alloc(&wctx, backend)) {
-        fprintf(stderr, "[EncDownsample] FATAL: backend allocation failed\n");
+        qt_log(QT_LOG_ERROR, "[EncDownsample] FATAL: backend allocation failed");
         return false;
     }
     d->weight_ctx = wctx.ctx;
@@ -41,8 +41,8 @@ static bool enc_down_load(QwenEncoderDownsample * d, const GGUFModel & gf, ggml_
     d->in_ch  = (int) d->weight->ne[1];
     d->out_ch = (int) d->weight->ne[2];
 
-    fprintf(stderr, "[EncDownsample] Loaded: k=%d stride=%d, %d -> %d channels, weights %.1f MB\n", d->kernel,
-            d->stride, d->in_ch, d->out_ch, (float) ggml_backend_buffer_get_size(d->weight_buf) / (1024.0f * 1024.0f));
+    qt_log(QT_LOG_INFO, "[EncDownsample] Loaded: k=%d stride=%d, %d -> %d channels, weights %.1f MB", d->kernel,
+           d->stride, d->in_ch, d->out_ch, (float) ggml_backend_buffer_get_size(d->weight_buf) / (1024.0f * 1024.0f));
     return true;
 }
 

--- a/src/encoder-transformer.h
+++ b/src/encoder-transformer.h
@@ -21,11 +21,11 @@
 #include "ggml-backend.h"
 #include "ggml.h"
 #include "gguf-weights.h"
+#include "qt-error.h"
 #include "weight-ctx.h"
 
 #include <cmath>
 #include <cstdint>
-#include <cstdio>
 #include <cstdlib>
 #include <string>
 #include <vector>
@@ -81,7 +81,7 @@ static bool enc_trans_load(QwenEncoderTransformer * tr, const GGUFModel & gf, gg
     tr->norm_eps            = gf_get_f32(gf, "qwen3-tts-tokenizer.encoder.norm_eps");
 
     if (num_layers == 0 || num_layers > (uint32_t) ENC_TRANS_MAX_LAYERS) {
-        fprintf(stderr, "[EncTransformer] FATAL: invalid layer count %u (max %d)\n", num_layers, ENC_TRANS_MAX_LAYERS);
+        qt_log(QT_LOG_ERROR, "[EncTransformer] FATAL: invalid layer count %u (max %d)", num_layers, ENC_TRANS_MAX_LAYERS);
         return false;
     }
 
@@ -110,17 +110,17 @@ static bool enc_trans_load(QwenEncoderTransformer * tr, const GGUFModel & gf, gg
     }
 
     if (!wctx_alloc(&wctx, backend)) {
-        fprintf(stderr, "[EncTransformer] FATAL: backend allocation failed\n");
+        qt_log(QT_LOG_ERROR, "[EncTransformer] FATAL: backend allocation failed");
         return false;
     }
     tr->weight_ctx = wctx.ctx;
     tr->weight_buf = wctx.buffer;
 
-    fprintf(stderr,
-            "[EncTransformer] Loaded: %d layers, hidden %d, heads %d/%d, head_dim %d, "
-            "FFN %d, RoPE theta %.0f\n",
-            tr->num_layers, tr->hidden_size, tr->num_attention_heads, tr->num_kv_heads, tr->head_dim,
-            tr->intermediate_size, tr->rope_theta);
+    qt_log(QT_LOG_INFO,
+           "[EncTransformer] Loaded: %d layers, hidden %d, heads %d/%d, head_dim %d, "
+           "FFN %d, RoPE theta %.0f",
+           tr->num_layers, tr->hidden_size, tr->num_attention_heads, tr->num_kv_heads, tr->head_dim,
+           tr->intermediate_size, tr->rope_theta);
     return true;
 }
 

--- a/src/gguf-weights.h
+++ b/src/gguf-weights.h
@@ -17,7 +17,6 @@
 #include "qt-error.h"
 #include "weight-ctx.h"
 
-#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <string>
@@ -83,7 +82,7 @@ static bool gf_load(GGUFModel * gf, const char * path) {
     gf->fh =
         CreateFileW(wpath.c_str(), GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
     if (gf->fh == INVALID_HANDLE_VALUE) {
-        fprintf(stderr, "[GGUF] Cannot open %s\n", path);
+        qt_log(QT_LOG_ERROR, "[GGUF] Cannot open %s", path);
         return false;
     }
     LARGE_INTEGER li;
@@ -92,20 +91,20 @@ static bool gf_load(GGUFModel * gf, const char * path) {
     gf->mh        = CreateFileMappingW(gf->fh, NULL, PAGE_READONLY, 0, 0, NULL);
     if (!gf->mh) {
         CloseHandle(gf->fh);
-        fprintf(stderr, "[GGUF] CreateFileMapping failed %s\n", path);
+        qt_log(QT_LOG_ERROR, "[GGUF] CreateFileMapping failed %s", path);
         return false;
     }
     gf->mapping = (uint8_t *) MapViewOfFile(gf->mh, FILE_MAP_READ, 0, 0, 0);
     if (!gf->mapping) {
         CloseHandle(gf->mh);
         CloseHandle(gf->fh);
-        fprintf(stderr, "[GGUF] MapViewOfFile failed %s\n", path);
+        qt_log(QT_LOG_ERROR, "[GGUF] MapViewOfFile failed %s", path);
         return false;
     }
 #else
     gf->fd = open(path, O_RDONLY);
     if (gf->fd < 0) {
-        fprintf(stderr, "[GGUF] Cannot open %s\n", path);
+        qt_log(QT_LOG_ERROR, "[GGUF] Cannot open %s", path);
         return false;
     }
     struct stat sb;
@@ -115,7 +114,7 @@ static bool gf_load(GGUFModel * gf, const char * path) {
     if (gf->mapping == MAP_FAILED) {
         close(gf->fd);
         gf->mapping = NULL;
-        fprintf(stderr, "[GGUF] Mmap failed %s\n", path);
+        qt_log(QT_LOG_ERROR, "[GGUF] Mmap failed %s", path);
         return false;
     }
 #endif
@@ -125,7 +124,7 @@ static bool gf_load(GGUFModel * gf, const char * path) {
     struct gguf_init_params params = { /*no_alloc=*/true, /*ctx=*/&meta };
     gf->gguf                       = gguf_init_from_file(path, params);
     if (!gf->gguf) {
-        fprintf(stderr, "[GGUF] Failed to parse %s\n", path);
+        qt_log(QT_LOG_ERROR, "[GGUF] Failed to parse %s", path);
         gf_close(gf);
         return false;
     }
@@ -144,17 +143,17 @@ static bool gf_load(GGUFModel * gf, const char * path) {
         size_t               tsize = ggml_nbytes(t);
         size_t               end   = gf->data_offset + toff + tsize;
         if (end > gf->file_size) {
-            fprintf(stderr,
-                    "[GGUF] FATAL: '%s' is truncated or corrupt.\n"
-                    "       tensor '%s' needs bytes [%zu..%zu) but file is only %zu bytes.\n"
-                    "       Re-download the file and verify its size or checksum.\n",
-                    path, tname, gf->data_offset + toff, end, gf->file_size);
+            qt_log(QT_LOG_ERROR,
+                   "[GGUF] FATAL: '%s' is truncated or corrupt. "
+                   "tensor '%s' needs bytes [%zu..%zu) but file is only %zu bytes. "
+                   "Re-download the file and verify its size or checksum.",
+                   path, tname, gf->data_offset + toff, end, gf->file_size);
             gf_close(gf);
             return false;
         }
     }
 
-    fprintf(stderr, "[GGUF] %s: %lld tensors, data at offset %zu\n", path, (long long) n, gf->data_offset);
+    qt_log(QT_LOG_INFO, "[GGUF] %s: %lld tensors, data at offset %zu", path, (long long) n, gf->data_offset);
     return true;
 }
 
@@ -233,8 +232,8 @@ static struct ggml_tensor * gf_load_tensor_f32(WeightCtx * wctx, const GGUFModel
 
     // Bail early on unsupported types (before creating tensor in ctx)
     if (src->type != GGML_TYPE_BF16 && src->type != GGML_TYPE_F16) {
-        fprintf(stderr, "[GGUF] WARNING: gf_load_tensor_f32 unsupported type %d for '%s', loading as-is\n", src->type,
-                name.c_str());
+        qt_log(QT_LOG_WARN, "[GGUF] WARNING: gf_load_tensor_f32 unsupported type %d for '%s', loading as-is", src->type,
+               name.c_str());
         return gf_load_tensor(wctx, gf, name);
     }
 

--- a/src/graph-arena.h
+++ b/src/graph-arena.h
@@ -6,9 +6,9 @@
 // every decode step instead of thrashing on fresh allocations.
 
 #include "ggml.h"
+#include "qt-error.h"
 
 #include <cstddef>
-#include <cstdio>
 
 struct GraphArena {
     struct ggml_context * ctx = nullptr;
@@ -21,7 +21,7 @@ static bool graph_arena_init(GraphArena * a, int max_nodes) {
     struct ggml_init_params gp = { bytes, NULL, true };
     a->ctx                     = ggml_init(gp);
     if (!a->ctx) {
-        fprintf(stderr, "[GraphArena] FATAL: ggml_init failed (%zu bytes)\n", bytes);
+        qt_log(QT_LOG_ERROR, "[GraphArena] FATAL: ggml_init failed (%zu bytes)", bytes);
         return false;
     }
     return true;

--- a/src/kv-cache.h
+++ b/src/kv-cache.h
@@ -18,9 +18,9 @@
 #include "ggml-alloc.h"
 #include "ggml-backend.h"
 #include "ggml.h"
+#include "qt-error.h"
 
 #include <cstddef>
-#include <cstdio>
 #include <cstdlib>
 #include <vector>
 
@@ -83,7 +83,7 @@ static bool kv_cache_init(KVCache *      kv,
     };
     kv->ctx = ggml_init(gp);
     if (!kv->ctx) {
-        fprintf(stderr, "[KVCache] FATAL: ggml_init failed\n");
+        qt_log(QT_LOG_ERROR, "[KVCache] FATAL: ggml_init failed");
         return false;
     }
 
@@ -112,7 +112,7 @@ static bool kv_cache_init(KVCache *      kv,
 
     kv->buffer = ggml_backend_alloc_ctx_tensors(kv->ctx, backend);
     if (!kv->buffer) {
-        fprintf(stderr, "[KVCache] FATAL: backend allocation failed\n");
+        qt_log(QT_LOG_ERROR, "[KVCache] FATAL: backend allocation failed");
         ggml_free(kv->ctx);
         kv->ctx = NULL;
         return false;
@@ -124,7 +124,7 @@ static bool kv_cache_init(KVCache *      kv,
     size_t bytes_per_layer =
         (size_t) head_dim * (size_t) max_seq_len * (size_t) n_kv_heads * (size_t) n_sets * sizeof(float);
     size_t total_mb = (size_t) (2 * n_layers) * bytes_per_layer / (1024 * 1024);
-    fprintf(stderr, "[KVCache] Allocated: %d layers, %d KV heads, head_dim %d, max_seq_len %d, %d sets -> %zu MB\n",
+    qt_log(QT_LOG_INFO, "[KVCache] Allocated: %d layers, %d KV heads, head_dim %d, max_seq_len %d, %d sets -> %zu MB",
             n_layers, n_kv_heads, head_dim, max_seq_len, n_sets, total_mb);
     return true;
 }

--- a/src/prompt-builder.h
+++ b/src/prompt-builder.h
@@ -50,7 +50,6 @@
 
 #include <cmath>
 #include <cstdint>
-#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <string>
@@ -282,7 +281,7 @@ static bool prompt_cache_load(PipelineTTS * pt) {
                                       (int32_t) pt->text_specials.tts_pad_id };
         std::vector<float> proj((size_t) 3 * (size_t) hidden);
         if (!project_text_ids_backend(pt, ids, 3, proj.data())) {
-            fprintf(stderr, "[Prompt] FATAL: special text projection failed\n");
+            qt_log(QT_LOG_ERROR, "[Prompt] FATAL: special text projection failed");
             return false;
         }
         std::memcpy(pc.tts_bos_emb.data(), proj.data() + (size_t) 0 * hidden, (size_t) hidden * sizeof(float));
@@ -377,7 +376,7 @@ static bool prompt_builder_build(PipelineTTS *         pt,
     const int hidden = pt->talker.hidden_size;
 
     if (!speaker_name.empty() && ref_spk_emb != NULL) {
-        fprintf(stderr, "[Prompt] FATAL: speaker_name and ref_spk_emb are mutually exclusive\n");
+        qt_log(QT_LOG_ERROR, "[Prompt] FATAL: speaker_name and ref_spk_emb are mutually exclusive");
         return false;
     }
 
@@ -385,7 +384,7 @@ static bool prompt_builder_build(PipelineTTS *         pt,
     // Mode B requires ref_spk_emb so the speaker slot is also filled.
     const bool icl = !ref_text.empty() && ref_codes != NULL && ref_codes_T > 0;
     if (icl && ref_spk_emb == NULL) {
-        fprintf(stderr, "[Prompt] FATAL: ICL mode requires ref_spk_emb (no --ref-wav?)\n");
+        qt_log(QT_LOG_ERROR, "[Prompt] FATAL: ICL mode requires ref_spk_emb (no --ref-wav?)");
         return false;
     }
 
@@ -400,7 +399,7 @@ static bool prompt_builder_build(PipelineTTS *         pt,
 
     std::vector<int> ids = bpe_encode(tok, full_text, /*add_eos=*/false);
     if ((int) ids.size() < 8) {
-        fprintf(stderr, "[Prompt] FATAL: tokenized prompt too short (%d tokens)\n", (int) ids.size());
+        qt_log(QT_LOG_ERROR, "[Prompt] FATAL: tokenized prompt too short (%d tokens)", (int) ids.size());
         return false;
     }
 
@@ -408,7 +407,7 @@ static bool prompt_builder_build(PipelineTTS *         pt,
     const int N      = (int) ids.size();
     const int N_text = N - 3 - 5;
     if (N_text <= 0) {
-        fprintf(stderr, "[Prompt] FATAL: no utterance text in prompt (N=%d)\n", N);
+        qt_log(QT_LOG_ERROR, "[Prompt] FATAL: no utterance text in prompt (N=%d)", N);
         return false;
     }
 
@@ -429,7 +428,7 @@ static bool prompt_builder_build(PipelineTTS *         pt,
                 }
             }
             if (language_id < 0) {
-                fprintf(stderr, "[Prompt] FATAL: unknown language '%s'\n", language.c_str());
+                qt_log(QT_LOG_ERROR, "[Prompt] FATAL: unknown language '%s'", language.c_str());
                 return false;
             }
         }
@@ -453,7 +452,7 @@ static bool prompt_builder_build(PipelineTTS *         pt,
             }
         }
         if (!found) {
-            fprintf(stderr, "[Prompt] FATAL: unknown speaker '%s'\n", speaker_name.c_str());
+            qt_log(QT_LOG_ERROR, "[Prompt] FATAL: unknown speaker '%s'", speaker_name.c_str());
             return false;
         }
         speaker_id = found->id;
@@ -475,7 +474,7 @@ static bool prompt_builder_build(PipelineTTS *         pt,
                     }
                 }
                 if (dialect_id < 0) {
-                    fprintf(stderr, "[Prompt] FATAL: dialect '%s' not in language table\n", found->dialect.c_str());
+                    qt_log(QT_LOG_ERROR, "[Prompt] FATAL: dialect '%s' not in language table", found->dialect.c_str());
                     return false;
                 }
                 language_id = dialect_id;
@@ -484,7 +483,7 @@ static bool prompt_builder_build(PipelineTTS *         pt,
     }
 
     if (!pt->prompt_cache.initialized) {
-        fprintf(stderr, "[Prompt] FATAL: prompt cache is not initialized\n");
+        qt_log(QT_LOG_ERROR, "[Prompt] FATAL: prompt cache is not initialized");
         return false;
     }
     PromptCache & pc = pt->prompt_cache;
@@ -550,13 +549,13 @@ static bool prompt_builder_build(PipelineTTS *         pt,
         ref_full += "<|im_end|>\n<|im_start|>assistant\n";
         ref_ids = bpe_encode(tok, ref_full, /*add_eos=*/false);
         if ((int) ref_ids.size() < 8) {
-            fprintf(stderr, "[Prompt] FATAL: ref_text tokenized too short (%d tokens)\n", (int) ref_ids.size());
+            qt_log(QT_LOG_ERROR, "[Prompt] FATAL: ref_text tokenized too short (%d tokens)", (int) ref_ids.size());
             return false;
         }
         // ref_ids[3: -5] is the inner ref text body without role tokens
         N_ref_text = (int) ref_ids.size() - 3 - 5;
         if (N_ref_text <= 0) {
-            fprintf(stderr, "[Prompt] FATAL: empty ref_text body\n");
+            qt_log(QT_LOG_ERROR, "[Prompt] FATAL: empty ref_text body");
             return false;
         }
     }
@@ -744,7 +743,7 @@ static bool prompt_builder_build(PipelineTTS *         pt,
     }
 
     if (row != T_ctx) {
-        fprintf(stderr, "[Prompt] FATAL: layout error row=%d expected T_ctx=%d\n", row, T_ctx);
+        qt_log(QT_LOG_ERROR, "[Prompt] FATAL: layout error row=%d expected T_ctx=%d", row, T_ctx);
         return false;
     }
 
@@ -767,12 +766,12 @@ static bool prompt_builder_build(PipelineTTS *         pt,
 
     out->tts_pad_embed = tts_pad_emb;
 
-    fprintf(stderr,
-            "[Prompt] Built: %d ids, N_text=%d, N_instruct=%d, T_ctx=%d, hidden=%d, lang=%s (id=%d), speaker=%s "
-            "(id=%d) ref_spk_emb=%s icl=%s\n",
-            N, N_text, N_instruct, T_ctx, hidden, language.c_str(), language_id,
-            speaker_name.empty() ? "none" : speaker_name.c_str(), speaker_id, ref_spk_emb ? "yes" : "no",
-            icl ? "yes" : "no");
+    qt_log(QT_LOG_INFO,
+           "[Prompt] Built: %d ids, N_text=%d, N_instruct=%d, T_ctx=%d, hidden=%d, lang=%s (id=%d), speaker=%s "
+           "(id=%d) ref_spk_emb=%s icl=%s",
+           N, N_text, N_instruct, T_ctx, hidden, language.c_str(), language_id,
+           speaker_name.empty() ? "none" : speaker_name.c_str(), speaker_id, ref_spk_emb ? "yes" : "no",
+           icl ? "yes" : "no");
 
     return true;
 }

--- a/src/quantizer-decode.h
+++ b/src/quantizer-decode.h
@@ -15,7 +15,6 @@
 #include "qt-error.h"
 #include "weight-ctx.h"
 
-#include <cstdio>
 #include <cstdlib>
 #include <string>
 
@@ -68,7 +67,7 @@ static bool quant_decoder_load(QwenQuantizerDecoder * dec, const GGUFModel & gf,
     dec->hidden                  = (int) gf_get_u32(gf, "qwen3-tts-tokenizer.decoder.vector_quantization_hidden_dim");
 
     if (dec->num_acoustic_quantizers > RVQ_MAX_CODEBOOKS_PER_GROUP) {
-        fprintf(stderr, "[Quantizer] FATAL: %d acoustic codebooks exceeds compile-time max %d\n",
+        qt_log(QT_LOG_ERROR, "[Quantizer] FATAL: %d acoustic codebooks exceeds compile-time max %d",
                 dec->num_acoustic_quantizers, RVQ_MAX_CODEBOOKS_PER_GROUP);
         return false;
     }
@@ -96,17 +95,17 @@ static bool quant_decoder_load(QwenQuantizerDecoder * dec, const GGUFModel & gf,
     }
 
     if (!wctx_alloc(&wctx, backend)) {
-        fprintf(stderr, "[Quantizer] FATAL: backend allocation failed\n");
+        qt_log(QT_LOG_ERROR, "[Quantizer] FATAL: backend allocation failed");
         return false;
     }
     dec->weight_ctx = wctx.ctx;
     dec->weight_buf = wctx.buffer;
 
-    fprintf(stderr,
-            "[Quantizer] Loaded: %d codebooks (%d semantic + %d acoustic), "
-            "%d entries x %d dim, hidden %d\n",
-            dec->num_quantizers, dec->num_semantic_quantizers, dec->num_acoustic_quantizers, dec->codebook_size,
-            dec->codebook_dim_internal, dec->hidden);
+    qt_log(QT_LOG_INFO,
+           "[Quantizer] Loaded: %d codebooks (%d semantic + %d acoustic), "
+           "%d entries x %d dim, hidden %d",
+           dec->num_quantizers, dec->num_semantic_quantizers, dec->num_acoustic_quantizers, dec->codebook_size,
+           dec->codebook_dim_internal, dec->hidden);
     return true;
 }
 
@@ -150,8 +149,8 @@ static struct ggml_tensor * quant_decode(struct ggml_context *        ctx,
                                          struct ggml_tensor *         codes) {
     int T = (int) codes->ne[0];
     if ((int) codes->ne[1] != dec->num_quantizers) {
-        fprintf(stderr, "[Quantizer] FATAL: codes ne[1]=%lld != num_quantizers=%d\n", (long long) codes->ne[1],
-                dec->num_quantizers);
+        qt_log(QT_LOG_ERROR, "[Quantizer] FATAL: codes ne[1]=%lld != num_quantizers=%d", (long long) codes->ne[1],
+               dec->num_quantizers);
         return NULL;
     }
 

--- a/src/quantizer-encode.h
+++ b/src/quantizer-encode.h
@@ -27,9 +27,9 @@
 #include "ggml-backend.h"
 #include "ggml.h"
 #include "gguf-weights.h"
+#include "qt-error.h"
 #include "weight-ctx.h"
 
-#include <cstdio>
 #include <cstdlib>
 #include <string>
 
@@ -84,17 +84,17 @@ static bool quant_encode_load(QwenQuantizerEncode * q, const GGUFModel & gf, ggm
     }
 
     if (!wctx_alloc(&wctx, backend)) {
-        fprintf(stderr, "[EncQuantizer] FATAL: backend allocation failed\n");
+        qt_log(QT_LOG_ERROR, "[EncQuantizer] FATAL: backend allocation failed");
         return false;
     }
     q->weight_ctx = wctx.ctx;
     q->weight_buf = wctx.buffer;
 
-    fprintf(stderr,
-            "[EncQuantizer] Loaded: %d codebooks (%d semantic + %d acoustic), %d entries x %d dim, "
-            "hidden %d, weights %.1f MB\n",
-            QUANT_ENC_TOTAL, QUANT_ENC_NUM_SEMANTIC, QUANT_ENC_NUM_ACOUSTIC, q->codebook_size, q->codebook_dim,
-            q->hidden_size, (float) ggml_backend_buffer_get_size(q->weight_buf) / (1024.0f * 1024.0f));
+    qt_log(QT_LOG_INFO,
+           "[EncQuantizer] Loaded: %d codebooks (%d semantic + %d acoustic), %d entries x %d dim, "
+           "hidden %d, weights %.1f MB",
+           QUANT_ENC_TOTAL, QUANT_ENC_NUM_SEMANTIC, QUANT_ENC_NUM_ACOUSTIC, q->codebook_size, q->codebook_dim,
+           q->hidden_size, (float) ggml_backend_buffer_get_size(q->weight_buf) / (1024.0f * 1024.0f));
     return true;
 }
 

--- a/src/rvq-file.h
+++ b/src/rvq-file.h
@@ -6,10 +6,10 @@
 // config in the GGUF; T is derived from the file size:
 // T = (filesize * 8) / (K * code_bits).
 
+#include "qt-error.h"
 #include "utf8.h"
 
 #include <cstdint>
-#include <cstdio>
 #include <string>
 #include <vector>
 
@@ -69,13 +69,13 @@ static bool rvq_read_buf(const uint8_t *        data,
                          std::vector<int32_t> & codes,
                          int *                  n_frames) {
     if (size == 0) {
-        fprintf(stderr, "[RVQ] FATAL: empty code stream\n");
+        qt_log(QT_LOG_ERROR, "[RVQ] FATAL: empty code stream");
         return false;
     }
     const size_t total_bits = size * 8;
     const size_t n_codes    = total_bits / (size_t) code_bits;
     if (n_codes == 0 || (n_codes % (size_t) K) != 0) {
-        fprintf(stderr, "[RVQ] FATAL: stream yields %zu codes, not a multiple of K=%d\n", n_codes, K);
+        qt_log(QT_LOG_ERROR, "[RVQ] FATAL: stream yields %zu codes, not a multiple of K=%d", n_codes, K);
         return false;
     }
     std::vector<uint8_t> buf(data, data + size);
@@ -87,20 +87,20 @@ static bool rvq_read_buf(const uint8_t *        data,
 static bool rvq_read_file(const char * path, int K, int code_bits, std::vector<int32_t> & codes, int * n_frames) {
     FILE * f = utf8_fopen(path, "rb");
     if (!f) {
-        fprintf(stderr, "[RVQ] FATAL: cannot open %s\n", path);
+        qt_log(QT_LOG_ERROR, "[RVQ] FATAL: cannot open %s", path);
         return false;
     }
     fseek(f, 0, SEEK_END);
     long sz = ftell(f);
     fseek(f, 0, SEEK_SET);
     if (sz <= 0) {
-        fprintf(stderr, "[RVQ] FATAL: %s is empty\n", path);
+        qt_log(QT_LOG_ERROR, "[RVQ] FATAL: %s is empty", path);
         fclose(f);
         return false;
     }
     std::vector<uint8_t> buf((size_t) sz);
     if (fread(buf.data(), 1, buf.size(), f) != buf.size()) {
-        fprintf(stderr, "[RVQ] FATAL: short read on %s\n", path);
+        qt_log(QT_LOG_ERROR, "[RVQ] FATAL: short read on %s", path);
         fclose(f);
         return false;
     }
@@ -113,11 +113,11 @@ static bool rvq_write_file(const char * path, const std::vector<int32_t> & codes
     std::vector<uint8_t> packed = rvq_pack_codes(codes, code_bits);
     FILE *               f      = utf8_fopen(path, "wb");
     if (!f) {
-        fprintf(stderr, "[RVQ] FATAL: cannot open %s for write\n", path);
+        qt_log(QT_LOG_ERROR, "[RVQ] FATAL: cannot open %s for write", path);
         return false;
     }
     if (fwrite(packed.data(), 1, packed.size(), f) != packed.size()) {
-        fprintf(stderr, "[RVQ] FATAL: short write on %s\n", path);
+        qt_log(QT_LOG_ERROR, "[RVQ] FATAL: short write on %s", path);
         fclose(f);
         return false;
     }

--- a/src/seanet-encoder.h
+++ b/src/seanet-encoder.h
@@ -24,9 +24,9 @@
 #include "ggml-backend.h"
 #include "ggml.h"
 #include "gguf-weights.h"
+#include "qt-error.h"
 #include "weight-ctx.h"
 
-#include <cstdio>
 #include <cstdlib>
 #include <string>
 
@@ -92,8 +92,8 @@ static bool seanet_encoder_load(QwenSEANetEncoder * s, const GGUFModel & gf, ggm
     {
         const auto & arr = gf_get_array_u32(gf, "qwen3-tts-tokenizer.encoder.upsampling_ratios");
         if ((int) arr.size() != SEANET_NUM_STAGES) {
-            fprintf(stderr, "[SEANet] FATAL: upsampling_ratios has %d entries, expected %d\n", (int) arr.size(),
-                    SEANET_NUM_STAGES);
+            qt_log(QT_LOG_ERROR, "[SEANet] FATAL: upsampling_ratios has %d entries, expected %d", (int) arr.size(),
+                   SEANET_NUM_STAGES);
             return false;
         }
         for (int i = 0; i < SEANET_NUM_STAGES; i++) {
@@ -145,17 +145,16 @@ static bool seanet_encoder_load(QwenSEANetEncoder * s, const GGUFModel & gf, ggm
     s->last_b = gf_load_tensor(&wctx, gf, "tok_enc.conv.14.bias");
 
     if (!wctx_alloc(&wctx, backend)) {
-        fprintf(stderr, "[SEANet] FATAL: backend allocation failed\n");
+        qt_log(QT_LOG_ERROR, "[SEANet] FATAL: backend allocation failed");
         return false;
     }
     s->weight_ctx = wctx.ctx;
     s->weight_buf = wctx.buffer;
 
-    fprintf(stderr,
-            "[SEANet] Loaded: 4 stages (ratios %d/%d/%d/%d), %d -> %d channels, "
-            "weights %.1f MB\n",
-            ratios[0], ratios[1], ratios[2], ratios[3], s->num_filters, s->hidden_size,
-            (float) ggml_backend_buffer_get_size(s->weight_buf) / (1024.0f * 1024.0f));
+    qt_log(QT_LOG_INFO,
+           "[SEANet] Loaded: 4 stages (ratios %d/%d/%d/%d), %d -> %d channels, weights %.1f MB",
+           ratios[0], ratios[1], ratios[2], ratios[3], s->num_filters, s->hidden_size,
+           (float) ggml_backend_buffer_get_size(s->weight_buf) / (1024.0f * 1024.0f));
     return true;
 }
 

--- a/src/speaker-encoder-extract.h
+++ b/src/speaker-encoder-extract.h
@@ -22,10 +22,10 @@
 #include "ggml-alloc.h"
 #include "ggml-backend.h"
 #include "ggml.h"
+#include "qt-error.h"
 #include "speaker-encoder-forward.h"
 #include "speaker-encoder-weights.h"
 
-#include <cstdio>
 #include <cstring>
 #include <memory>
 #include <vector>
@@ -42,11 +42,11 @@ static bool speaker_encoder_extract(const SpeakerEncoderWeights * sw,
                                     std::vector<float> &          emb_out,
                                     const char *                  dump_dir = NULL) {
     if (sw->weight_buf == NULL) {
-        fprintf(stderr, "[SpkExtract] FATAL: speaker encoder weights not loaded\n");
+        qt_log(QT_LOG_ERROR, "[SpkExtract] FATAL: speaker encoder weights not loaded");
         return false;
     }
     if (!audio || n_samples <= 0) {
-        fprintf(stderr, "[SpkExtract] FATAL: empty audio buffer\n");
+        qt_log(QT_LOG_ERROR, "[SpkExtract] FATAL: empty audio buffer");
         return false;
     }
 
@@ -64,7 +64,7 @@ static bool speaker_encoder_extract(const SpeakerEncoderWeights * sw,
     const int pad   = (mel_cfg.n_fft - mel_cfg.hop) / 2;  // 384
     const int T_pad = T_in + 2 * pad;
     if (T_in < pad + 1) {
-        fprintf(stderr, "[SpkExtract] FATAL: audio too short (%d samples) for reflect pad %d\n", T_in, pad);
+        qt_log(QT_LOG_ERROR, "[SpkExtract] FATAL: audio too short (%d samples) for reflect pad %d", T_in, pad);
         return false;
     }
 
@@ -203,7 +203,7 @@ static bool speaker_encoder_extract(const SpeakerEncoderWeights * sw,
     // a residual graph state from a previous synthesis call.
     ggml_backend_sched_reset(sched);
     if (!ggml_backend_sched_alloc_graph(sched, graph)) {
-        fprintf(stderr, "[SpkExtract] FATAL: graph allocation failed\n");
+        qt_log(QT_LOG_ERROR, "[SpkExtract] FATAL: graph allocation failed");
         ggml_free(gctx);
         return false;
     }
@@ -216,7 +216,7 @@ static bool speaker_encoder_extract(const SpeakerEncoderWeights * sw,
     ggml_backend_tensor_set(mel_b_in, mel_c.mel_basis.data(), 0, mel_c.mel_basis.size() * sizeof(float));
 
     if (ggml_backend_sched_graph_compute(sched, graph) != GGML_STATUS_SUCCESS) {
-        fprintf(stderr, "[SpkExtract] FATAL: graph compute failed\n");
+        qt_log(QT_LOG_ERROR, "[SpkExtract] FATAL: graph compute failed");
         ggml_backend_sched_reset(sched);
         ggml_free(gctx);
         return false;
@@ -286,6 +286,6 @@ static bool speaker_encoder_extract(const SpeakerEncoderWeights * sw,
     ggml_backend_sched_reset(sched);
     ggml_free(gctx);
 
-    fprintf(stderr, "[SpkExtract] Extracted %d-dim embedding (%d samples, padded %d)\n", sw->enc_dim, T_in, T_pad);
+    qt_log(QT_LOG_INFO, "[SpkExtract] Extracted %d-dim embedding (%d samples, padded %d)", sw->enc_dim, T_in, T_pad);
     return true;
 }

--- a/src/speaker-encoder-weights.h
+++ b/src/speaker-encoder-weights.h
@@ -23,10 +23,10 @@
 #include "ggml-backend.h"
 #include "ggml.h"
 #include "gguf-weights.h"
+#include "qt-error.h"
 #include "weight-ctx.h"
 
 #include <cstdint>
-#include <cstdio>
 #include <cstring>
 #include <string>
 #include <vector>
@@ -159,7 +159,7 @@ static bool speaker_encoder_weights_load(SpeakerEncoderWeights * sw, const GGUFM
     // Probe: Base GGUFs ship the speaker encoder, CustomVoice and
     // VoiceDesign do not. A missing conv0.weight aborts cleanly.
     if (gguf_find_tensor(gf.gguf, "spk_enc.conv0.weight") < 0) {
-        fprintf(stderr, "[SpeakerEncoder] No spk_enc.conv0.weight, base/clone mode unavailable\n");
+        qt_log(QT_LOG_WARN, "[SpeakerEncoder] No spk_enc.conv0.weight, base/clone mode unavailable");
         sw->weight_ctx = NULL;
         sw->weight_buf = NULL;
         return true;
@@ -183,16 +183,16 @@ static bool speaker_encoder_weights_load(SpeakerEncoderWeights * sw, const GGUFM
     sw->fc_b       = spk_load(&wctx, gf, "spk_enc.fc.bias");
 
     if (!wctx_alloc(&wctx, backend)) {
-        fprintf(stderr, "[SpeakerEncoder] FATAL: backend allocation failed\n");
+        qt_log(QT_LOG_ERROR, "[SpeakerEncoder] FATAL: backend allocation failed");
         return false;
     }
     sw->weight_ctx = wctx.ctx;
     sw->weight_buf = wctx.buffer;
 
-    fprintf(stderr,
-            "[SpeakerEncoder] Loaded: enc_dim=%d sr=%d mel_dim=%d hidden=%d mfa=%d asp_attn=%d se=%d scale=%d\n",
-            sw->enc_dim, sw->sample_rate, sw->mel_dim, sw->hidden, sw->mfa_hidden, sw->asp_attn, sw->se_channels,
-            sw->res2net_scale);
+    qt_log(QT_LOG_INFO,
+           "[SpeakerEncoder] Loaded: enc_dim=%d sr=%d mel_dim=%d hidden=%d mfa=%d asp_attn=%d se=%d scale=%d",
+           sw->enc_dim, sw->sample_rate, sw->mel_dim, sw->hidden, sw->mfa_hidden, sw->asp_attn, sw->se_channels,
+           sw->res2net_scale);
     return true;
 }
 

--- a/src/talker-forward.h
+++ b/src/talker-forward.h
@@ -47,7 +47,6 @@
 
 #include <cmath>
 #include <cstdint>
-#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <vector>
@@ -369,7 +368,7 @@ static bool talker_forward_core(const TalkerWeights * tw,
 
     ggml_backend_sched_reset(sched);
     if (!ggml_backend_sched_alloc_graph(sched, gf)) {
-        fprintf(stderr, "[TalkerForward] FATAL: graph allocation failed\n");
+        qt_log(QT_LOG_ERROR, "[TalkerForward] FATAL: graph allocation failed");
         ggml_backend_sched_reset(sched);
         return false;
     }
@@ -413,7 +412,7 @@ static bool talker_forward_core(const TalkerWeights * tw,
     }
 
     if (ggml_backend_sched_graph_compute(sched, gf) != GGML_STATUS_SUCCESS) {
-        fprintf(stderr, "[TalkerForward] FATAL: graph compute failed\n");
+        qt_log(QT_LOG_ERROR, "[TalkerForward] FATAL: graph compute failed");
         ggml_backend_sched_reset(sched);
         return false;
     }
@@ -480,7 +479,7 @@ static bool talker_forward_prefill(const TalkerWeights * tw,
                                    TalkerForwardOutput * out) {
     kv_cache_reset(kv, kv_set);
     if (T > kv->max_seq_len) {
-        fprintf(stderr, "[TalkerForward] FATAL: prefill T=%d exceeds cache max_seq_len=%d\n", T, kv->max_seq_len);
+        qt_log(QT_LOG_ERROR, "[TalkerForward] FATAL: prefill T=%d exceeds cache max_seq_len=%d", T, kv->max_seq_len);
         return false;
     }
     return talker_forward_core(tw, kv, kv_set, sched, arena, hidden_bridge, input_embed, T, 0, use_flash_attn,
@@ -640,7 +639,7 @@ static bool talker_decode_graph_build(const TalkerWeights *        tw,
     struct ggml_init_params gp = { bytes, NULL, true };
     tg->ctx                    = ggml_init(gp);
     if (!tg->ctx) {
-        fprintf(stderr, "[TalkerForward] FATAL: decode graph ctx allocation failed\n");
+        qt_log(QT_LOG_ERROR, "[TalkerForward] FATAL: decode graph ctx allocation failed");
         return false;
     }
     struct ggml_context * gctx = tg->ctx;
@@ -697,7 +696,7 @@ static bool talker_decode_graph_build(const TalkerWeights *        tw,
 
     tg->galloc = ggml_gallocr_new(ggml_backend_get_default_buffer_type(backend));
     if (!tg->galloc || !ggml_gallocr_alloc_graph(tg->galloc, gf)) {
-        fprintf(stderr, "[TalkerForward] FATAL: decode graph allocation failed\n");
+        qt_log(QT_LOG_ERROR, "[TalkerForward] FATAL: decode graph allocation failed");
         talker_decode_graph_free(tg);
         return false;
     }
@@ -745,8 +744,8 @@ static bool talker_forward_decode(const TalkerWeights *            tw,
     for (int i = 0; i < N; i++) {
         const int len = kv->cur_len[(size_t) i] + 1;
         if (len > kv->max_seq_len) {
-            fprintf(stderr, "[TalkerForward] FATAL: decode would overflow cache (%d > %d, set %d)\n", len,
-                    kv->max_seq_len, i);
+            qt_log(QT_LOG_ERROR, "[TalkerForward] FATAL: decode would overflow cache (%d > %d, set %d)", len,
+                   kv->max_seq_len, i);
             return false;
         }
         if (len > max_len) {
@@ -791,7 +790,7 @@ static bool talker_forward_decode(const TalkerWeights *            tw,
     }
 
     if (ggml_backend_graph_compute(backend, tg->gf) != GGML_STATUS_SUCCESS) {
-        fprintf(stderr, "[TalkerForward] FATAL: decode graph compute failed\n");
+        qt_log(QT_LOG_ERROR, "[TalkerForward] FATAL: decode graph compute failed");
         return false;
     }
 

--- a/src/talker-weights.h
+++ b/src/talker-weights.h
@@ -35,10 +35,10 @@
 #include "ggml-backend.h"
 #include "ggml.h"
 #include "gguf-weights.h"
+#include "qt-error.h"
 #include "weight-ctx.h"
 
 #include <cstdint>
-#include <cstdio>
 #include <cstring>
 #include <string>
 #include <vector>
@@ -117,8 +117,8 @@ static bool talker_weights_load(TalkerWeights * tw, const GGUFModel & gf, ggml_b
     }
 
     if (tw->num_hidden_layers <= 0 || tw->hidden_size <= 0) {
-        fprintf(stderr, "[Talker] FATAL: invalid hyperparameters in GGUF (layers=%d hidden=%d)\n",
-                tw->num_hidden_layers, tw->hidden_size);
+        qt_log(QT_LOG_ERROR, "[Talker] FATAL: invalid hyperparameters in GGUF (layers=%d hidden=%d)",
+               tw->num_hidden_layers, tw->hidden_size);
         return false;
     }
 
@@ -171,18 +171,18 @@ static bool talker_weights_load(TalkerWeights * tw, const GGUFModel & gf, ggml_b
     }
 
     if (!wctx_alloc(&wctx, backend)) {
-        fprintf(stderr, "[Talker] FATAL: backend allocation failed\n");
+        qt_log(QT_LOG_ERROR, "[Talker] FATAL: backend allocation failed");
         return false;
     }
     tw->weight_ctx = wctx.ctx;
     tw->weight_buf = wctx.buffer;
 
-    fprintf(stderr,
-            "[Talker] Loaded: %d layers, hidden %d, heads %d/%d, head_dim %d, "
-            "FFN %d, RoPE theta %.0f, mrope sections [%d,%d,%d] interleaved=%d\n",
-            tw->num_hidden_layers, tw->hidden_size, tw->num_attention_heads, tw->num_key_value_heads, tw->head_dim,
-            tw->intermediate_size, (double) tw->rope_theta, tw->mrope_section_t, tw->mrope_section_h,
-            tw->mrope_section_w, (int) tw->mrope_interleaved);
+    qt_log(QT_LOG_INFO,
+           "[Talker] Loaded: %d layers, hidden %d, heads %d/%d, head_dim %d, "
+           "FFN %d, RoPE theta %.0f, mrope sections [%d,%d,%d] interleaved=%d",
+           tw->num_hidden_layers, tw->hidden_size, tw->num_attention_heads, tw->num_key_value_heads, tw->head_dim,
+           tw->intermediate_size, (double) tw->rope_theta, tw->mrope_section_t, tw->mrope_section_h,
+           tw->mrope_section_w, (int) tw->mrope_interleaved);
     return true;
 }
 

--- a/src/tokenizer-transformer.h
+++ b/src/tokenizer-transformer.h
@@ -14,11 +14,11 @@
 #include "ggml.h"
 #include "gguf-weights.h"
 #include "kv-cache.h"
+#include "qt-error.h"
 #include "weight-ctx.h"
 
 #include <cmath>
 #include <cstdint>
-#include <cstdio>
 #include <cstdlib>
 #include <string>
 #include <vector>
@@ -87,7 +87,7 @@ static bool tok_trans_load(QwenTokenizerTransformer * tr, const GGUFModel & gf, 
     tr->rms_norm_eps        = gf_get_f32(gf, "qwen3-tts-tokenizer.decoder.rms_norm_eps");
 
     if (num_layers == 0 || num_layers > (uint32_t) TOK_TRANS_MAX_LAYERS) {
-        fprintf(stderr, "[Transformer] FATAL: invalid layer count %u (max %d)\n", num_layers, TOK_TRANS_MAX_LAYERS);
+        qt_log(QT_LOG_ERROR, "[Transformer] FATAL: invalid layer count %u (max %d)", num_layers, TOK_TRANS_MAX_LAYERS);
         return false;
     }
 
@@ -137,17 +137,17 @@ static bool tok_trans_load(QwenTokenizerTransformer * tr, const GGUFModel & gf, 
     }
 
     if (!wctx_alloc(&wctx, backend)) {
-        fprintf(stderr, "[Transformer] FATAL: backend allocation failed\n");
+        qt_log(QT_LOG_ERROR, "[Transformer] FATAL: backend allocation failed");
         return false;
     }
     tr->weight_ctx = wctx.ctx;
     tr->weight_buf = wctx.buffer;
 
-    fprintf(stderr,
-            "[Transformer] Loaded: %d layers, hidden %d, heads %d/%d, head_dim %d, "
-            "FFN %d, RoPE theta %.0f, sliding window %d\n",
-            tr->num_layers, tr->hidden_size, tr->num_attention_heads, tr->num_kv_heads, tr->head_dim,
-            tr->intermediate_size, tr->rope_theta, tr->sliding_window);
+    qt_log(QT_LOG_INFO,
+           "[Transformer] Loaded: %d layers, hidden %d, heads %d/%d, head_dim %d, "
+           "FFN %d, RoPE theta %.0f, sliding window %d",
+           tr->num_layers, tr->hidden_size, tr->num_attention_heads, tr->num_kv_heads, tr->head_dim,
+           tr->intermediate_size, tr->rope_theta, tr->sliding_window);
     return true;
 }
 

--- a/src/tts-server.h
+++ b/src/tts-server.h
@@ -24,6 +24,7 @@
 
 #include "../vendor/cpp-httplib/httplib.h"
 #include "audio-io.h"
+#include "qt-error.h"
 #include "yyjson.h"
 
 #include <atomic>
@@ -32,7 +33,6 @@
 #include <condition_variable>
 #include <csignal>
 #include <cstdint>
-#include <cstdio>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -578,10 +578,10 @@ static int tts_server_run(const tts_backend & be, const server_config & cfg) {
     signal(SIGINT, tts_on_signal);
     signal(SIGTERM, tts_on_signal);
 
-    fprintf(stderr, "[Server] model %s\n", be.model_id.c_str());
-    fprintf(stderr, "[Server] listening on %s:%d\n", cfg.host.c_str(), cfg.port);
+    qt_log(QT_LOG_INFO, "[Server] model %s", be.model_id.c_str());
+    qt_log(QT_LOG_INFO, "[Server] listening on %s:%d", cfg.host.c_str(), cfg.port);
     if (!svr.listen(cfg.host.c_str(), cfg.port)) {
-        fprintf(stderr, "[Server] FATAL: cannot bind %s:%d\n", cfg.host.c_str(), cfg.port);
+        qt_log(QT_LOG_ERROR, "[Server] FATAL: cannot bind %s:%d", cfg.host.c_str(), cfg.port);
         return 1;
     }
     return 0;

--- a/src/wav.h
+++ b/src/wav.h
@@ -4,8 +4,9 @@
 // read_wav_buf: PCM16 / PCM24 / float32, classic or WAVE_FORMAT_EXTENSIBLE,
 //               mono or stereo, any rate -> interleaved [T, 2] float
 
+#include "qt-error.h"
+
 #include <cstdint>
-#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <vector>
@@ -42,7 +43,7 @@ static float * read_wav_buf(const uint8_t * data, size_t size, int * T_audio, in
     *sr      = 0;
 
     if (size < 12 || memcmp(data, "RIFF", 4) != 0 || memcmp(data + 8, "WAVE", 4) != 0) {
-        fprintf(stderr, "[WAV] Not a valid WAV buffer\n");
+        qt_log(QT_LOG_ERROR, "[WAV] Not a valid WAV buffer");
         return NULL;
     }
 
@@ -90,7 +91,7 @@ static float * read_wav_buf(const uint8_t * data, size_t size, int * T_audio, in
                 n_samples = (int) (data_bytes / ((size_t) n_channels * 2));
                 audio     = (float *) malloc((size_t) n_samples * 2 * sizeof(float));
                 if (!audio) {
-                    fprintf(stderr, "[WAV] OOM allocating PCM16 buffer for %d samples\n", n_samples);
+                    qt_log(QT_LOG_ERROR, "[WAV] OOM allocating PCM16 buffer for %d samples", n_samples);
                     return NULL;
                 }
                 const uint8_t * p = data + pos;
@@ -113,7 +114,7 @@ static float * read_wav_buf(const uint8_t * data, size_t size, int * T_audio, in
                 n_samples = (int) (data_bytes / ((size_t) n_channels * 3));
                 audio     = (float *) malloc((size_t) n_samples * 2 * sizeof(float));
                 if (!audio) {
-                    fprintf(stderr, "[WAV] OOM allocating PCM24 buffer for %d samples\n", n_samples);
+                    qt_log(QT_LOG_ERROR, "[WAV] OOM allocating PCM24 buffer for %d samples", n_samples);
                     return NULL;
                 }
                 const uint8_t * p = data + pos;
@@ -136,7 +137,7 @@ static float * read_wav_buf(const uint8_t * data, size_t size, int * T_audio, in
                 n_samples = (int) (data_bytes / ((size_t) n_channels * 4));
                 audio     = (float *) malloc((size_t) n_samples * 2 * sizeof(float));
                 if (!audio) {
-                    fprintf(stderr, "[WAV] OOM allocating F32 buffer for %d samples\n", n_samples);
+                    qt_log(QT_LOG_ERROR, "[WAV] OOM allocating F32 buffer for %d samples", n_samples);
                     return NULL;
                 }
                 const uint8_t * p = data + pos;
@@ -155,8 +156,8 @@ static float * read_wav_buf(const uint8_t * data, size_t size, int * T_audio, in
                     }
                 }
             } else {
-                fprintf(stderr, "[WAV] Unsupported: format=%u bits=%d subformat=%u\n", (unsigned) audio_format,
-                        bits_per_sample, (unsigned) extensible_subformat);
+                qt_log(QT_LOG_ERROR, "[WAV] Unsupported: format=%u bits=%d subformat=%u",
+                       (unsigned) audio_format, bits_per_sample, (unsigned) extensible_subformat);
                 return NULL;
             }
 
@@ -171,13 +172,13 @@ static float * read_wav_buf(const uint8_t * data, size_t size, int * T_audio, in
     }
 
     if (!audio) {
-        fprintf(stderr, "[WAV] No audio data in buffer\n");
+        qt_log(QT_LOG_ERROR, "[WAV] No audio data in buffer");
         return NULL;
     }
 
     *T_audio = n_samples;
     *sr      = sample_rate;
-    fprintf(stderr, "[WAV] Read buffer: %d samples, %d Hz, %d ch, %d bit\n", n_samples, sample_rate, n_channels,
-            bits_per_sample);
+    qt_log(QT_LOG_INFO, "[WAV] Read buffer: %d samples, %d Hz, %d ch, %d bit", n_samples, sample_rate, n_channels,
+           bits_per_sample);
     return audio;
 }

--- a/src/weight-ctx.h
+++ b/src/weight-ctx.h
@@ -12,9 +12,9 @@
 
 #include "ggml-backend.h"
 #include "ggml.h"
+#include "qt-error.h"
 
 #include <cstddef>
-#include <cstdio>
 #include <memory>
 #include <vector>
 
@@ -53,7 +53,7 @@ static void wctx_init(WeightCtx * wctx, int n_tensors) {
 static bool wctx_alloc(WeightCtx * wctx, ggml_backend_t backend) {
     wctx->buffer = ggml_backend_alloc_ctx_tensors(wctx->ctx, backend);
     if (!wctx->buffer) {
-        fprintf(stderr, "[WeightCtx] FATAL: failed to allocate backend buffer\n");
+        qt_log(QT_LOG_ERROR, "[WeightCtx] FATAL: failed to allocate backend buffer");
         return false;
     }
     // Mark as weight buffer so ggml_backend_sched assigns ops to the correct
@@ -64,8 +64,8 @@ static bool wctx_alloc(WeightCtx * wctx, ggml_backend_t backend) {
         ggml_backend_tensor_set(pc.tensor, pc.src, pc.offset, pc.nbytes);
         total += pc.nbytes;
     }
-    fprintf(stderr, "[WeightCtx] Loaded %zu tensors, %.1f MB into backend\n", wctx->pending.size(),
-            (float) total / (1024 * 1024));
+    qt_log(QT_LOG_INFO, "[WeightCtx] Loaded %zu tensors, %.1f MB into backend", wctx->pending.size(),
+           (float) total / (1024 * 1024));
     wctx->pending.clear();
     wctx->staging.clear();
     return true;


### PR DESCRIPTION
## Replace `fprintf` with `qt_log` across all library sources

### What changed

All `fprintf(stderr, ...)` call sites in the `src/` library have been replaced
with `qt_log(QT_LOG_xxx, ...)` across 27 header files.

Headers that did not yet include `qt-error.h` gained the include; the
now-redundant `#include <cstdio>` was removed from each of those files.

### Why it was needed

Previously, wrapping the library in a higher-level binding meant that load
progress, warnings, and fatal errors would bypass whatever logging framework
the host application used and land on `stderr` unconditionally. With this
change, a single `qt_log_set(cb, user_data)` call redirects everything --
Python `logging`, Rust `tracing`, Android logcat, or any other sink.

### Severity mapping

| Level | Used for |
|---|---|
| `QT_LOG_ERROR` | `FATAL` / OOM / file I/O / graph compute failures |
| `QT_LOG_WARN` | Recoverable surprises (missing optional GGUF keys, unknown tokens, unsupported-but-fallback paths) |
| `QT_LOG_INFO` | Normal load and synthesis cadence (model loaded, N layers, weights MB, samples written, etc.) |
| `QT_LOG_DEBUG` | Tensor dump shape lines and GGML dedup notices |

### Intentional exclusions

- The single `std::fprintf` inside `qt_log`'s own stderr fallback path (`qwen.cpp`) is untouched -- it **is** the fallback implementation itself.
- The `tools/` CLI executables are out of scope; their `fprintf` output is direct terminal UX, not library diagnostics.
